### PR TITLE
feat: Jacoco 테스트 커버리지 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,14 @@ jacocoTestReport {
 
 jacocoTestCoverageVerification {
     violationRules {
+        rule {
+            element = 'CLASS'
 
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,12 @@ jacocoTestCoverageVerification {
             element = 'CLASS'
 
             limit {
-                counter = 'BRANCH'
+                counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
                 minimum = 0.90
             }
+
+            includes = ['*.domain.*']
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.90
+                minimum = 0.80
             }
 
             includes = ['*.domain.*']


### PR DESCRIPTION
## Resolve #19 

- 빌드 시 테스트 통과 기준을 정하기 위해 필요

## Changes

- Instruction(Java ByteCode) 기준으로 테스트 커버리지가 최소 80%를 넘기도록 설정


## Notes

- 도메인 패키지를 대상으로 설정되어있음.

## References

- [우아한 형제들 기술 블로그 - Gradle 프로젝트에 Jacoco 설정하기](https://woowabros.github.io/experience/2020/02/02/jacoco-config-on-gradle-project.html) 
