### PR TITLE
fix: UNICODE 문자 앞에 \ 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic_template.md
+++ b/.github/ISSUE_TEMPLATE/epic_template.md
@@ -1,6 +1,6 @@
 ---
 name: Epic template
-about: "세부 기능을 포괄하는 Epic 생성 U+1F5C2"
+about: "세부 기능을 포괄하는 Epic 생성 \U+1F5C2"
 title: "[EPIC] 제목"
 labels: ''
 assignees: ''

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -7832,8 +7832,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",


### PR DESCRIPTION
## Resolve #27 

- Epic 템플릿 제목에 emoji가 보이지 않는 현상 수정

## Changes

- UNICODE 앞에 `\` 추가

## Notes

- N/A

## References

- https://www.compart.com/en/unicode/U+1F5C2
