### PR TITLE
feat: 메인 페이지 레이아웃 구현

### DIFF
--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Do+Hyeon&display=swap" rel="stylesheet">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,11 +1,14 @@
 <template>
   <div id="app">
-    {{ message }}
+    <navigation-bar></navigation-bar>
+    <footer-bar></footer-bar>
   </div>
 </template>
 
 <script>
 import axios from "axios";
+import NavigationBar from "./components/NavagationBar.vue";
+import FooterBar from "./components/FooterBar.vue";
 
 export default {
   data() {
@@ -13,8 +16,11 @@ export default {
       message: ""
     };
   },
+  components: {
+    NavigationBar,
+    FooterBar
+  },
   async mounted() {
-    //http://localhost:8080/api/hello
     const { data } = await axios.get("/api/hello");
     this.message = data;
   }
@@ -22,12 +28,7 @@ export default {
 </script>
 
 <style>
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
+body {
+  font-family: "Do Hyeon", sans-serif;
 }
 </style>

--- a/src/frontend/src/components/FooterBar.vue
+++ b/src/frontend/src/components/FooterBar.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <v-footer dark padless absolute color="#87BDD6" id="footer">
+      <v-card flat tile color="#87BDD6" class="lighten-1 white--text">
+        <v-card-text>
+          <v-btn
+            v-for="icon in icons"
+            :key="icon"
+            class="mx-4 white--text"
+            icon
+          >
+            <v-icon size="24px">{{ icon }}</v-icon>
+          </v-btn>
+        </v-card-text>
+
+        <v-card-text class="white--text pt-0">
+          Phasellus feugiat arcu sapien, et iaculis ipsum elementum sit amet.
+          Mauris cursus commodo interdum. Praesent ut risus eget metus luctus
+          accumsan id ultrices nunc.
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-text class="white--text">
+          {{ new Date().getFullYear() }} — <strong>Underdogs</strong>
+        </v-card-text>
+      </v-card>
+    </v-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      icons: ["mdi-facebook", "mdi-github", "mdi-linkedin", "mdi-instagram"]
+    };
+  }
+};
+</script>
+
+<style scoped>
+#footer {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+</style>

--- a/src/frontend/src/components/NavagationBar.vue
+++ b/src/frontend/src/components/NavagationBar.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <v-app-bar color="#87BDD6" name="navigation">
+      <v-app-bar-nav-icon id="logo">icon</v-app-bar-nav-icon>
+      <v-toolbar-title id="home-title">Devbie</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn text x-large><p class="navigation-menu">공고</p></v-btn>
+      <v-btn text x-large><p class="navigation-menu">면접</p></v-btn>
+      <v-btn large color="#E8E8E8" id="login-btn">Login with Github</v-btn>
+    </v-app-bar>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style scoped>
+#logo {
+  margin-left: 50px;
+}
+#home-title {
+  font-size: 28px;
+  color: #f4f4f4;
+}
+.navigation-menu {
+  font-size: 24px;
+  color: #f4f4f4;
+}
+#login-btn {
+  margin-right: 40px;
+}
+</style>

--- a/src/frontend/src/main.js
+++ b/src/frontend/src/main.js
@@ -1,8 +1,10 @@
 import Vue from "vue";
 import App from "./App.vue";
+import vuetify from "@/plugins/vuetify";
 
 Vue.config.productionTip = false;
 
 new Vue({
+  vuetify,
   render: h => h(App)
 }).$mount("#app");

--- a/src/frontend/src/plugins/vuetify.js
+++ b/src/frontend/src/plugins/vuetify.js
@@ -1,0 +1,13 @@
+import Vue from "vue";
+import Vuetify from "vuetify";
+import "vuetify/dist/vuetify.min.css";
+
+Vue.use(Vuetify);
+
+const opts = {
+  icons: {
+    iconfont: "mdiSvg"
+  }
+};
+
+export default new Vuetify(opts);


### PR DESCRIPTION
## Resolve #25 

- 메인 페이지 레이아웃 구현

## Changes

- navigation bar, footer 컴포넌트 생성

## Notes

- 로그인 버튼에 아이콘 추가
- 본문 내용은 타 기능 구현 후 업데이트 예정


## References

- [Vuetify](https://vuetifyjs.com/en/)
