### PR TITLE
fix: Unicode 포맷을 python source로 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic_template.md
+++ b/.github/ISSUE_TEMPLATE/epic_template.md
@@ -1,6 +1,6 @@
 ---
 name: Epic template
-about: "세부 기능을 포괄하는 Epic 생성 \U+1F5C2"
+about: "세부 기능을 포괄하는 Epic 생성 \U0001F5C2"
 title: "[EPIC] 제목"
 labels: ''
 assignees: ''


### PR DESCRIPTION
## Resolve #32 

- 잘못된 포맷으로 Epic template이 깨짐

## Changes

- Unicode format을 python source로 변경

## Notes

- 정상적으로 동작하는 것 확인

## References

- https://www.fileformat.info/info/unicode/char/1f5c2/index.htm
