### PR TITLE
refactor: 빌드환경별 application.properties 분기하도록 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,10 @@ yarn-error.log
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij,visualstudiocode,vue,vuejs
 
 # underdogs
+src/main/resources/static
 application-*.yml
+application-*.properties
+
 src/frontend/npm-v*
 .gradle
 build

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.moowork.node' version '1.3.1'
     id 'java'
     id 'jacoco'
+    id 'application'
 }
 
 group = 'underdogs'
@@ -31,6 +32,17 @@ task buildFrontend(type: NpmTask, dependsOn: setUp) {
 }
 
 //processResources.dependsOn 'buildFrontend'
+
+def environment = '';
+
+if ("$System.env.DEVBIE_ENVIRONMENT" == "product") {
+    environment = 'product'
+}
+if ("$System.env.DEVBIE_ENVIRONMENT" == "develop") {
+    environment = 'develop'
+}
+
+applicationDefaultJvmArgs = ["-Dspring.profiles.active=" + environment];
 
 configurations {
     compileOnly {


### PR DESCRIPTION
## Resolve #34 

- 빌드환경별로 필요한 properties가 필요하다.

## Changes

- build.gradle에서 시스템 환경변수별 JVM 옵션을 분기한다.

## Notes

- 로컬에서는 application-default.properties를 사용한다.
- 프로덕션에서는 application-product.properties를 사용한다.
- develop 서버에서는 application-develop.properties를 사용한다.

## References

- N/A
