### PR TITLE
test: User Controller, Service, Domain 테스트 코드 작성

### DIFF
--- a/src/frontend/src/components/LoginPage.vue
+++ b/src/frontend/src/components/LoginPage.vue
@@ -4,7 +4,7 @@ export default {
   async created() {
     const code = this.$route.query.code;
 
-    const response = await axios.post("/api/oauth/login?code=" + code);
+    const response = await axios.post("/api/auth/login?code=" + code);
     const { token } = await response.data;
 
     localStorage.setItem("devbieToken", token);

--- a/src/main/java/underdogs/devbie/auth/controller/AuthController.java
+++ b/src/main/java/underdogs/devbie/auth/controller/AuthController.java
@@ -12,7 +12,7 @@ import underdogs.devbie.auth.dto.JwtTokenResponse;
 import underdogs.devbie.auth.service.AuthService;
 
 @RestController
-@RequestMapping("/api/oauth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/underdogs/devbie/auth/dto/UserInfoResponse.java
+++ b/src/main/java/underdogs/devbie/auth/dto/UserInfoResponse.java
@@ -12,7 +12,6 @@ import underdogs.devbie.user.domain.User;
 public class UserInfoResponse {
 
     private String id;
-    private String login;
     private String email;
 
     public User toEntity() {

--- a/src/main/java/underdogs/devbie/config/AuthConfig.java
+++ b/src/main/java/underdogs/devbie/config/AuthConfig.java
@@ -21,7 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(bearerAuthInterceptor)
             .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/oauth/login", "/api/oauth/login-url");
+            .excludePathPatterns("/api/auth/login", "/api/auth/login-url");
     }
 
     @Override

--- a/src/main/java/underdogs/devbie/user/controller/UserController.java
+++ b/src/main/java/underdogs/devbie/user/controller/UserController.java
@@ -11,8 +11,8 @@ import underdogs.devbie.user.dto.UserResponse;
 @RestController
 public class UserController {
 
-	@GetMapping("/api/user")
-	public ResponseEntity<UserResponse> findUser(@LoginUser User user) {
-		return ResponseEntity.ok(UserResponse.from(user));
-	}
+    @GetMapping("/api/user")
+    public ResponseEntity<UserResponse> findUser(@LoginUser User user) {
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
 }

--- a/src/main/java/underdogs/devbie/user/controller/UserController.java
+++ b/src/main/java/underdogs/devbie/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package underdogs.devbie.user.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,8 +11,8 @@ import underdogs.devbie.user.dto.UserResponse;
 @RestController
 public class UserController {
 
-    @GetMapping("/api/user")
-    public ResponseEntity<UserResponse> test(@LoginUser User user) {
-        return ResponseEntity.ok(UserResponse.from(user));
-    }
+	@GetMapping("/api/user")
+	public ResponseEntity<UserResponse> findUser(@LoginUser User user) {
+		return ResponseEntity.ok(UserResponse.from(user));
+	}
 }

--- a/src/main/java/underdogs/devbie/user/domain/User.java
+++ b/src/main/java/underdogs/devbie/user/domain/User.java
@@ -27,7 +27,7 @@ public class User {
 
     private String email;
 
-    public User updateOAuthInfo(UserInfoResponse userInfoResponse) {
+    public User updateOauthInfo(UserInfoResponse userInfoResponse) {
         validateUserInfo(userInfoResponse);
         this.email = userInfoResponse.getEmail();
         return this;

--- a/src/main/java/underdogs/devbie/user/service/UserService.java
+++ b/src/main/java/underdogs/devbie/user/service/UserService.java
@@ -18,7 +18,7 @@ public class UserService {
     @Transactional
     public User saveOrUpdateUser(UserInfoResponse userInfoResponse) {
         User user = userRepository.findByOauthId(userInfoResponse.getId())
-            .map(u -> u.updateOAuthInfo(userInfoResponse))
+            .map(u -> u.updateOauthInfo(userInfoResponse))
             .orElse(userInfoResponse.toEntity());
 
         userRepository.save(user);

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -37,7 +37,7 @@ public class AuthControllerTest extends MvcTest {
     void fetchLoginUrl() throws Exception {
         given(authService.fetchLoginUrl()).willReturn(TEST_LOGIN_URL);
 
-        String url = "/api/oauth/login-url";
+        String url = "/api/auth/login-url";
 
         getAction(url)
                 .andExpect(status().isOk())
@@ -50,7 +50,7 @@ public class AuthControllerTest extends MvcTest {
     void login() throws Exception {
         given(authService.createToken(TEST_CODE)).willReturn(JwtTokenResponse.from(TEST_TOKEN));
 
-        String url = "/api/oauth/login" + "?code=" + TEST_CODE;
+        String url = "/api/auth/login" + "?code=" + TEST_CODE;
 
         postAction(url)
                 .andExpect(status().isOk())

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -17,16 +17,18 @@ import underdogs.devbie.auth.dto.JwtTokenResponse;
 import underdogs.devbie.auth.service.AuthService;
 
 @WebMvcTest(AuthController.class)
-class AuthControllerTest extends MvcTest {
+public class AuthControllerTest extends MvcTest {
 
+    public static final String TEST_TOKEN = "testToken";
     private static final String TEST_LOGIN_URL = "login-url";
-    private static final String TEST_TOKEN = "testToken";
     private static final String TEST_CODE = "1234";
 
     @MockBean
     private AuthService authService;
+
     @MockBean
     private BearerAuthInterceptor bearerAuthInterceptor;
+
     @MockBean
     private LoginUserArgumentResolver loginUserArgumentResolver;
 

--- a/src/test/java/underdogs/devbie/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/underdogs/devbie/auth/jwt/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package underdogs.devbie.auth.jwt;
 
 import static org.assertj.core.api.Assertions.*;
+import static underdogs.devbie.user.domain.UserTest.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,22 +15,19 @@ class JwtTokenProviderTest {
 
     private JwtTokenProvider jwtTokenProvider;
 
-    private final Long userId = 1L;
-    private User user;
-
     @BeforeEach
     void setUp() {
         jwtTokenProvider = new JwtTokenProvider("secretKey", 360000);
-        user = User.builder()
-            .id(userId)
-            .oauthId("oauthId")
-            .email("email")
-            .build();
     }
 
     @DisplayName("jwt 토큰 생성")
     @Test
     void createToken() {
+        User user = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
         String token = jwtTokenProvider.createToken(UserTokenDto.from(user));
 
         assertThat(token).isNotBlank();
@@ -38,11 +36,16 @@ class JwtTokenProviderTest {
     @DisplayName("jwt 토큰 복호화")
     @Test
     void extractValidSubject() {
+        User user = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
         String token = jwtTokenProvider.createToken(UserTokenDto.from(user));
 
         String extractedUserId = jwtTokenProvider.extractValidSubject(token);
 
-        assertThat(extractedUserId).isEqualTo(String.valueOf(userId));
+        assertThat(extractedUserId).isEqualTo(String.valueOf(1L));
     }
 
     @DisplayName("jwt 토큰 복호화 - 유효하지 않은 토큰")

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.StringContains.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static underdogs.devbie.user.domain.UserTest.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,34 +23,34 @@ import underdogs.devbie.user.domain.User;
 @AutoConfigureMockMvc
 class UserControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-	@MockBean
-	private BearerAuthInterceptor bearerAuthInterceptor;
+    @MockBean
+    private BearerAuthInterceptor bearerAuthInterceptor;
 
-	@MockBean
-	private LoginUserArgumentResolver loginUserArgumentResolver;
+    @MockBean
+    private LoginUserArgumentResolver loginUserArgumentResolver;
 
-	@DisplayName("유저 정보 조회")
-	@Test
-	void findUser() throws Exception {
-		// given
-		User user = User.builder()
-			.id(1L)
-			.oauthId("123456")
-			.email("test@test.com")
-			.build();
-		given(bearerAuthInterceptor.preHandle(any(), any(), any())).willReturn(true);
-		given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
-		given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+    @DisplayName("유저 정보 조회")
+    @Test
+    void findUser() throws Exception {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
+        given(bearerAuthInterceptor.preHandle(any(), any(), any())).willReturn(true);
+        given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
 
-		// when
-		mockMvc.perform(get("/api/user")
-			.header("Authorization", "bearer JWT_ACCESS_TOKEN")
-			.contentType(MediaType.APPLICATION_JSON))
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("\"email\":\"test@test.com\"")));
-	}
+        // when
+        mockMvc.perform(get("/api/user")
+            .header("Authorization", "bearer JWT_ACCESS_TOKEN")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"email\":\"underdogs@devbie.link\"")));
+    }
 
 }

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -1,0 +1,55 @@
+package underdogs.devbie.user.controller;
+
+import static org.hamcrest.core.StringContains.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
+import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
+import underdogs.devbie.user.domain.User;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private BearerAuthInterceptor bearerAuthInterceptor;
+
+	@MockBean
+	private LoginUserArgumentResolver loginUserArgumentResolver;
+
+	@DisplayName("유저 정보 조회")
+	@Test
+	void findUser() throws Exception {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.oauthId("123456")
+			.email("test@test.com")
+			.build();
+		given(bearerAuthInterceptor.preHandle(any(), any(), any())).willReturn(true);
+		given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
+		given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+
+		// when
+		mockMvc.perform(get("/api/user")
+			.header("Authorization", "bearer JWT_ACCESS_TOKEN")
+			.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string(containsString("\"email\":\"test@test.com\"")));
+	}
+
+}

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -33,7 +33,6 @@ class UserControllerTest {
     @DisplayName("유저 정보 조회")
     @Test
     void findUser() throws Exception {
-        // given
         User user = User.builder()
             .id(1L)
             .oauthId(TEST_OAUTH_ID)
@@ -43,7 +42,6 @@ class UserControllerTest {
         given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
         given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
 
-        // when
         mockMvc.perform(get("/api/user")
             .header("Authorization", "bearer JWT_ACCESS_TOKEN")
             .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -9,8 +9,7 @@ import static underdogs.devbie.user.domain.UserTest.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,8 +18,7 @@ import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
 import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
 import underdogs.devbie.user.domain.User;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest
 class UserControllerTest {
 
     @Autowired
@@ -52,5 +50,4 @@ class UserControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().string(containsString("\"email\":\"underdogs@devbie.link\"")));
     }
-
 }

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -18,7 +18,7 @@ import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
 import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
 import underdogs.devbie.user.domain.User;
 
-@WebMvcTest
+@WebMvcTest(UserController.class)
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
+++ b/src/test/java/underdogs/devbie/user/controller/UserControllerTest.java
@@ -2,27 +2,22 @@ package underdogs.devbie.user.controller;
 
 import static org.hamcrest.core.StringContains.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static underdogs.devbie.auth.controller.AuthControllerTest.*;
 import static underdogs.devbie.user.domain.UserTest.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
+import underdogs.devbie.MvcTest;
 import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
 import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
 import underdogs.devbie.user.domain.User;
 
 @WebMvcTest(UserController.class)
-class UserControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class UserControllerTest extends MvcTest {
 
     @MockBean
     private BearerAuthInterceptor bearerAuthInterceptor;
@@ -42,10 +37,8 @@ class UserControllerTest {
         given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
         given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
 
-        mockMvc.perform(get("/api/user")
-            .header("Authorization", "bearer JWT_ACCESS_TOKEN")
-            .contentType(MediaType.APPLICATION_JSON))
+        getAction("/api/user", TEST_TOKEN)
             .andExpect(status().isOk())
-            .andExpect(content().string(containsString("\"email\":\"underdogs@devbie.link\"")));
+            .andExpect(content().string(containsString(TEST_USER_EMAIL)));
     }
 }

--- a/src/test/java/underdogs/devbie/user/domain/UserTest.java
+++ b/src/test/java/underdogs/devbie/user/domain/UserTest.java
@@ -1,0 +1,53 @@
+package underdogs.devbie.user.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import underdogs.devbie.auth.dto.UserInfoResponse;
+
+@SpringBootTest
+public class UserTest {
+
+    public static final String TEST_USER_EMAIL = "underdogs@devbie.link";
+    public static final String TEST_OAUTH_ID = "TEST_OAUTH_ID";
+
+    @DisplayName("OauthId가 일치하지 않을 경우 예외발생")
+    @Test
+    void validateUserInfo() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
+        UserInfoResponse userInfoResponse = new UserInfoResponse("Different Oauth Id", TEST_USER_EMAIL);
+
+        // when
+        assertThatThrownBy(() -> {
+            user.updateOauthInfo(userInfoResponse);
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("Oauth 유저 정보 업데이트")
+    @Test
+    void updateOauthInfo() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
+        UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, "Changed Email");
+
+        // when
+        User updatedUser = user.updateOauthInfo(userInfoResponse);
+
+        // then
+        assertThat(updatedUser.getId()).isEqualTo(1L);
+        assertThat(updatedUser.getOauthId()).isEqualTo(TEST_OAUTH_ID);
+        assertThat(updatedUser.getEmail()).isEqualTo("Changed Email");
+    }
+}

--- a/src/test/java/underdogs/devbie/user/domain/UserTest.java
+++ b/src/test/java/underdogs/devbie/user/domain/UserTest.java
@@ -1,6 +1,7 @@
 package underdogs.devbie.user.domain;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,6 @@ public class UserTest {
     @DisplayName("OauthId가 일치하지 않을 경우 예외발생")
     @Test
     void validateUserInfo() {
-        // given
         User user = User.builder()
             .id(1L)
             .oauthId(TEST_OAUTH_ID)
@@ -23,16 +23,13 @@ public class UserTest {
             .build();
         UserInfoResponse userInfoResponse = new UserInfoResponse("Different Oauth Id", TEST_USER_EMAIL);
 
-        // when
-        assertThatThrownBy(() -> {
-            user.updateOauthInfo(userInfoResponse);
-        }).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> user.updateOauthInfo(userInfoResponse))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("Oauth 유저 정보 업데이트")
     @Test
     void updateOauthInfo() {
-        // given
         User user = User.builder()
             .id(1L)
             .oauthId(TEST_OAUTH_ID)
@@ -40,12 +37,12 @@ public class UserTest {
             .build();
         UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, "Changed Email");
 
-        // when
         User updatedUser = user.updateOauthInfo(userInfoResponse);
 
-        // then
-        assertThat(updatedUser.getId()).isEqualTo(1L);
-        assertThat(updatedUser.getOauthId()).isEqualTo(TEST_OAUTH_ID);
-        assertThat(updatedUser.getEmail()).isEqualTo("Changed Email");
+        assertAll(
+            () -> assertEquals(1L, updatedUser.getId()),
+            () -> assertEquals(TEST_OAUTH_ID, updatedUser.getOauthId()),
+            () -> assertEquals("Changed Email", updatedUser.getEmail())
+        );
     }
 }

--- a/src/test/java/underdogs/devbie/user/domain/UserTest.java
+++ b/src/test/java/underdogs/devbie/user/domain/UserTest.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import underdogs.devbie.auth.dto.UserInfoResponse;
 
-@SpringBootTest
 public class UserTest {
 
     public static final String TEST_USER_EMAIL = "underdogs@devbie.link";

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -11,13 +11,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import underdogs.devbie.auth.dto.UserInfoResponse;
 import underdogs.devbie.user.domain.User;
 import underdogs.devbie.user.domain.UserRepository;
 
-@SpringBootTest
 class UserServiceTest {
 
     private UserService userService;

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package underdogs.devbie.user.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static underdogs.devbie.user.domain.UserTest.*;
 
@@ -23,50 +23,49 @@ class UserServiceTest {
     @Mock
     private UserRepository userRepository;
 
-    private User mockUser;
-
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
 
         userService = new UserService(userRepository);
-        mockUser = User.builder()
-            .id(1L)
-            .oauthId(TEST_OAUTH_ID)
-            .email(TEST_USER_EMAIL)
-            .build();
     }
 
     @DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
     @Test
     void saveOrUpdateOauthUser() {
-        // given
+        User mockUser =  User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
         UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, TEST_USER_EMAIL);
         given(userRepository.findByOauthId(any())).willReturn(Optional.of(mockUser));
 
-        // when
         User user = userService.saveOrUpdateUser(userInfoResponse);
 
-        // then
-        verify(userRepository).findByOauthId(TEST_OAUTH_ID);
-        assertThat(user.getId()).isEqualTo(1L);
-        assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
-        assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+        assertAll(
+            () -> assertEquals(1L, user.getId()),
+            () -> assertEquals(TEST_OAUTH_ID, user.getOauthId()),
+            () -> assertEquals(TEST_USER_EMAIL, user.getEmail())
+        );
     }
 
     @DisplayName("Id로 유저 조회")
     @Test
     void findById() {
-        // given
+        User mockUser =  User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
         given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
 
-        // when
         User user = userService.findById(mockUser.getId());
 
-        // then
-        verify(userRepository).findById(eq(1L));
-        assertThat(user.getId()).isEqualTo(1L);
-        assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
-        assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+        assertAll(
+            () -> assertEquals(1L, user.getId()),
+            () -> assertEquals(TEST_OAUTH_ID, user.getOauthId()),
+            () -> assertEquals(TEST_USER_EMAIL, user.getEmail())
+        );
     }
 }

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -9,13 +9,15 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import underdogs.devbie.auth.dto.UserInfoResponse;
 import underdogs.devbie.user.domain.User;
 import underdogs.devbie.user.domain.UserRepository;
 
+@ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
     private UserService userService;
@@ -25,8 +27,6 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
-
         userService = new UserService(userRepository);
     }
 

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -1,0 +1,57 @@
+package underdogs.devbie.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import underdogs.devbie.auth.dto.UserInfoResponse;
+import underdogs.devbie.user.domain.User;
+import underdogs.devbie.user.domain.UserRepository;
+
+@SpringBootTest
+class UserServiceTest {
+
+	public static final String TEST_USER_EMAIL = "underdogs@debvie.link";
+	public static final String TEST_OAUTH_ID = "TEST_OAUTH_ID";
+
+	private UserService userService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		userService = new UserService(userRepository);
+	}
+
+	@DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
+	@Test
+	void saveOrUpdateOauthUser() {
+	    // given
+		UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, TEST_USER_EMAIL);
+		User mockUser = User.builder()
+			.id(1L)
+			.oauthId(TEST_OAUTH_ID)
+			.email(TEST_USER_EMAIL)
+			.build();
+		given(userRepository.findByOauthId(any())).willReturn(Optional.of(mockUser));
+
+	    // when
+		User user = userService.saveOrUpdateUser(userInfoResponse);
+
+		// then
+		assertThat(user.getId()).isEqualTo(1L);
+		assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
+		assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+	}
+}

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package underdogs.devbie.user.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static underdogs.devbie.user.domain.UserTest.*;
 
 import java.util.Optional;
 
@@ -19,58 +20,55 @@ import underdogs.devbie.user.domain.UserRepository;
 @SpringBootTest
 class UserServiceTest {
 
-	public static final String TEST_USER_EMAIL = "underdogs@debvie.link";
-	public static final String TEST_OAUTH_ID = "TEST_OAUTH_ID";
+    private UserService userService;
 
-	private UserService userService;
+    @Mock
+    private UserRepository userRepository;
 
-	@Mock
-	private UserRepository userRepository;
+    private User mockUser;
 
-	private User mockUser;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
 
-	@BeforeEach
-	void setUp() {
-		MockitoAnnotations.initMocks(this);
+        userService = new UserService(userRepository);
+        mockUser = User.builder()
+            .id(1L)
+            .oauthId(TEST_OAUTH_ID)
+            .email(TEST_USER_EMAIL)
+            .build();
+    }
 
-		userService = new UserService(userRepository);
-		mockUser = User.builder()
-			.id(1L)
-			.oauthId(TEST_OAUTH_ID)
-			.email(TEST_USER_EMAIL)
-			.build();
-	}
+    @DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
+    @Test
+    void saveOrUpdateOauthUser() {
+        // given
+        UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, TEST_USER_EMAIL);
+        given(userRepository.findByOauthId(any())).willReturn(Optional.of(mockUser));
 
-	@DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
-	@Test
-	void saveOrUpdateOauthUser() {
-	    // given
-		UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, TEST_USER_EMAIL);
-		given(userRepository.findByOauthId(any())).willReturn(Optional.of(mockUser));
+        // when
+        User user = userService.saveOrUpdateUser(userInfoResponse);
 
-	    // when
-		User user = userService.saveOrUpdateUser(userInfoResponse);
+        // then
+        verify(userRepository).findByOauthId(TEST_OAUTH_ID);
+        assertThat(user.getId()).isEqualTo(1L);
+        assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
+        assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+    }
 
-		// then
-		verify(userRepository).findByOauthId(TEST_OAUTH_ID);
-		assertThat(user.getId()).isEqualTo(1L);
-		assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
-		assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
-	}
+    @DisplayName("Id로 유저 조회")
+    @Test
+    void findById() {
+        // given
+        given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
 
-	@DisplayName("Id로 유저 조회")
-	@Test
-	void findById() {
-	    // given
-		given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
+        // when
+        User user = userService.findById(mockUser.getId());
 
-	    // when
-		User user = userService.findById(mockUser.getId());
-
-		// then
-		verify(userRepository).findById(eq(1L));
-		assertThat(user.getId()).isEqualTo(1L);
-		assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
-		assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
-	}
+        // then
+        verify(userRepository).findById(eq(1L));
+        assertThat(user.getId()).isEqualTo(1L);
+        assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
+        assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+    }
 }

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -27,11 +27,18 @@ class UserServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	private User mockUser;
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.initMocks(this);
 
 		userService = new UserService(userRepository);
+		mockUser = User.builder()
+			.id(1L)
+			.oauthId(TEST_OAUTH_ID)
+			.email(TEST_USER_EMAIL)
+			.build();
 	}
 
 	@DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
@@ -39,17 +46,29 @@ class UserServiceTest {
 	void saveOrUpdateOauthUser() {
 	    // given
 		UserInfoResponse userInfoResponse = new UserInfoResponse(TEST_OAUTH_ID, TEST_USER_EMAIL);
-		User mockUser = User.builder()
-			.id(1L)
-			.oauthId(TEST_OAUTH_ID)
-			.email(TEST_USER_EMAIL)
-			.build();
 		given(userRepository.findByOauthId(any())).willReturn(Optional.of(mockUser));
 
 	    // when
 		User user = userService.saveOrUpdateUser(userInfoResponse);
 
 		// then
+		verify(userRepository).findByOauthId(TEST_OAUTH_ID);
+		assertThat(user.getId()).isEqualTo(1L);
+		assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
+		assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+	}
+
+	@DisplayName("Id로 유저 조회")
+	@Test
+	void findById() {
+	    // given
+		given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
+
+	    // when
+		User user = userService.findById(mockUser.getId());
+
+		// then
+		verify(userRepository).findById(eq(1L));
 		assertThat(user.getId()).isEqualTo(1L);
 		assertThat(user.getOauthId()).isEqualTo(TEST_OAUTH_ID);
 		assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);


### PR DESCRIPTION
## Resolve #44

- 유저 인증과 유저 정보를 조회하는 코드에 대한 테스트가 필요하다.

## Changes

- UserControllerTest, UserServiceTest, UserTest 클래스를 만들고 각각에 단위테스트를 추가했다.

## Notes

- N/A

## References

- [JUnit5 소개 - 자바캔 블로그](https://javacan.tistory.com/entry/JUnit-5-Intro)
