### PR TITLE
test: AuthController 테스트 코드 작성

### DIFF
--- a/src/test/java/underdogs/devbie/MvcTest.java
+++ b/src/test/java/underdogs/devbie/MvcTest.java
@@ -14,10 +14,24 @@ public abstract class MvcTest {
     @Autowired
     protected MockMvc mockMvc;
 
+    protected ResultActions getAction(String url) throws Exception {
+        return this.mockMvc
+                .perform(get(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON));
+    }
+
     protected ResultActions getAction(String url, String bearerToken) throws Exception {
         return this.mockMvc
                 .perform(get(url)
                         .header(AUTH_HEADER, bearerToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    protected ResultActions postAction(String url) throws Exception {
+        return this.mockMvc
+                .perform(post(url)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON));
     }

--- a/src/test/java/underdogs/devbie/MvcTest.java
+++ b/src/test/java/underdogs/devbie/MvcTest.java
@@ -11,16 +11,16 @@ public abstract class MvcTest {
     @Autowired
     protected MockMvc mockMvc;
 
-    protected ResultActions getAction(String url, String inputJson, String bearerToken) throws Exception{
+    protected ResultActions getAction(String url, String inputJson, String bearerToken) throws Exception {
         return this.mockMvc
                 .perform(get(url)
-                .header("authorization", bearerToken)
-                .content(inputJson)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON));
+                        .header("authorization", bearerToken)
+                        .content(inputJson)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON));
     }
 
-    protected ResultActions postAction(String url, String inputJson, String bearerToken) throws Exception{
+    protected ResultActions postAction(String url, String inputJson, String bearerToken) throws Exception {
         return this.mockMvc
                 .perform(post(url)
                         .header("authorization", bearerToken)

--- a/src/test/java/underdogs/devbie/MvcTest.java
+++ b/src/test/java/underdogs/devbie/MvcTest.java
@@ -1,0 +1,31 @@
+package underdogs.devbie;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+public abstract class MvcTest {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected ResultActions getAction(String url, String inputJson, String bearerToken) throws Exception{
+        return this.mockMvc
+                .perform(get(url)
+                .header("authorization", bearerToken)
+                .content(inputJson)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    protected ResultActions postAction(String url, String inputJson, String bearerToken) throws Exception{
+        return this.mockMvc
+                .perform(post(url)
+                        .header("authorization", bearerToken)
+                        .content(inputJson)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON));
+    }
+}

--- a/src/test/java/underdogs/devbie/MvcTest.java
+++ b/src/test/java/underdogs/devbie/MvcTest.java
@@ -8,14 +8,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 public abstract class MvcTest {
+
+    private static final String AUTH_HEADER = "Authorization";
+
     @Autowired
     protected MockMvc mockMvc;
 
-    protected ResultActions getAction(String url, String inputJson, String bearerToken) throws Exception {
+    protected ResultActions getAction(String url, String bearerToken) throws Exception {
         return this.mockMvc
                 .perform(get(url)
-                        .header("authorization", bearerToken)
-                        .content(inputJson)
+                        .header(AUTH_HEADER, bearerToken)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON));
     }
@@ -23,7 +25,7 @@ public abstract class MvcTest {
     protected ResultActions postAction(String url, String inputJson, String bearerToken) throws Exception {
         return this.mockMvc
                 .perform(post(url)
-                        .header("authorization", bearerToken)
+                        .header(AUTH_HEADER, bearerToken)
                         .content(inputJson)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON));

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -16,7 +16,6 @@ import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
 import underdogs.devbie.auth.dto.JwtTokenResponse;
 import underdogs.devbie.auth.service.AuthService;
 
-@DisplayName("Auth컨트롤러")
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends MvcTest {
 
@@ -36,7 +35,9 @@ class AuthControllerTest extends MvcTest {
     void fetchLoginUrl() throws Exception {
         given(authService.fetchLoginUrl()).willReturn(TEST_LOGIN_URL);
 
-        getAction("/api/oauth/login-url", "", "")
+        String url = "/api/oauth/login-url";
+
+        getAction(url, "")
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(TEST_LOGIN_URL)))
                 .andDo(print());

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -44,7 +44,7 @@ class AuthControllerTest extends MvcTest {
 
     @DisplayName("로그인")
     @Test
-    void login() throws Exception{
+    void login() throws Exception {
         given(authService.createToken(TEST_CODE)).willReturn(JwtTokenResponse.from(TEST_TOKEN));
 
         String url = "/api/oauth/login" + "?code=" + TEST_CODE;

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,10 +13,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import underdogs.devbie.MvcTest;
 import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
 import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
+import underdogs.devbie.auth.dto.JwtTokenResponse;
 import underdogs.devbie.auth.service.AuthService;
 
+@DisplayName("Auth컨트롤러")
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends MvcTest {
+
+    private static final String TEST_LOGIN_URL = "login-url";
+    private static final String TEST_TOKEN = "testToken";
+    private static final String TEST_CODE = "1234";
 
     @MockBean
     private AuthService authService;
@@ -24,21 +31,27 @@ class AuthControllerTest extends MvcTest {
     @MockBean
     private LoginUserArgumentResolver loginUserArgumentResolver;
 
+    @DisplayName("fetch 로그인 url")
     @Test
     void fetchLoginUrl() throws Exception {
-        given(authService.fetchLoginUrl()).willReturn("fetch-login-url");
+        given(authService.fetchLoginUrl()).willReturn(TEST_LOGIN_URL);
 
         getAction("/api/oauth/login-url", "", "")
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("fetch-login-url")))
+                .andExpect(content().string(containsString(TEST_LOGIN_URL)))
                 .andDo(print());
     }
 
+    @DisplayName("로그인")
     @Test
     void login() throws Exception{
+        given(authService.createToken(TEST_CODE)).willReturn(JwtTokenResponse.from(TEST_TOKEN));
 
-        postAction("/api/oauth/login?code=1234", "", "")
+        String url = "/api/oauth/login" + "?code=" + TEST_CODE;
+
+        postAction(url, "", "")
                 .andExpect(status().isOk())
+                .andExpect(content().string(containsString(TEST_TOKEN)))
                 .andDo(print());
     }
 }

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -1,0 +1,44 @@
+package underdogs.devbie.auth.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import underdogs.devbie.MvcTest;
+import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
+import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
+import underdogs.devbie.auth.service.AuthService;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest extends MvcTest {
+
+    @MockBean
+    private AuthService authService;
+    @MockBean
+    private BearerAuthInterceptor bearerAuthInterceptor;
+    @MockBean
+    private LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Test
+    void fetchLoginUrl() throws Exception {
+        given(authService.fetchLoginUrl()).willReturn("fetch-login-url");
+
+        getAction("/api/oauth/login-url", "", "")
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("fetch-login-url")))
+                .andDo(print());
+    }
+
+    @Test
+    void login() throws Exception{
+
+        postAction("/api/oauth/login?code=1234", "", "")
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -37,7 +37,7 @@ class AuthControllerTest extends MvcTest {
 
         String url = "/api/oauth/login-url";
 
-        getAction(url, "")
+        getAction(url)
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(TEST_LOGIN_URL)))
                 .andDo(print());
@@ -50,7 +50,7 @@ class AuthControllerTest extends MvcTest {
 
         String url = "/api/oauth/login" + "?code=" + TEST_CODE;
 
-        postAction(url, "", "")
+        postAction(url)
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(TEST_TOKEN)))
                 .andDo(print());


### PR DESCRIPTION
## Resolve #46 

- AuthController 테스트 코드를 작성하지 않아서 추가

## Changes

- JwtTokenProviderTest 클래스에 테스트 작성

## Notes

- 현재 Interceptor와 Resolver는 사용되지 않아서 테스트 미작성

- SpringBootTest말고 WebMvcTest 사용
    - Interceptor와 Resolver는 사용되지 않더라도 컨텍스트안에 포함시켜주어야 WebMvcTest가 동작 (현재는 MockBean으로 포함)

- AuthController에 경로가 /api/oauth로 되어있음 -> /api/auth로 수정해야할 듯

- @DisplayName과 @Test 순서 다같이 통일해야 할 듯
