### PR TITLE
feat: BaseTimeEntity 생성

### DIFF
--- a/src/main/java/underdogs/devbie/config/AuditingConfig.java
+++ b/src/main/java/underdogs/devbie/config/AuditingConfig.java
@@ -1,0 +1,9 @@
+package underdogs.devbie.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class AuditingConfig {
+}

--- a/src/main/java/underdogs/devbie/config/BaseTimeEntity.java
+++ b/src/main/java/underdogs/devbie/config/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package underdogs.devbie.config;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/underdogs/devbie/user/domain/User.java
+++ b/src/main/java/underdogs/devbie/user/domain/User.java
@@ -11,13 +11,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import underdogs.devbie.auth.dto.UserInfoResponse;
+import underdogs.devbie.config.BaseTimeEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 @Builder
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Resolve #54 

- Entity의 생성에 공통적으로 필요한 필드들을 상위 Entity로 추출해야 한다.

## Changes

- AuditingConfig class를 추가
- BaseTimeEntity에는 최초 생성 시간, 마지막 업데이트 시간이 포함


## Notes

- N/A

## References

- N/A
