### PR TITLE
feat: AcceptanceTest를 위한 CRUD Template 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,16 +92,16 @@ jacocoTestReport {
 
 jacocoTestCoverageVerification {
     violationRules {
-//        rule {
-//            element = 'CLASS'
-//
-//            limit {
-//                counter = 'INSTRUCTION'
-//                value = 'COVEREDRATIO'
-//                minimum = 0.50
-//            }
-//
-//            includes = ['*.domain.*']
-//        }
+        rule {
+            element = 'CLASS'
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+
+            includes = ['*.domain.*']
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testImplementation 'io.rest-assured:rest-assured:3.3.0'
 }
 
 test {
@@ -91,16 +92,16 @@ jacocoTestReport {
 
 jacocoTestCoverageVerification {
     violationRules {
-        rule {
-            element = 'CLASS'
-
-            limit {
-                counter = 'INSTRUCTION'
-                value = 'COVEREDRATIO'
-                minimum = 0.50
-            }
-
-            includes = ['*.domain.*']
-        }
+//        rule {
+//            element = 'CLASS'
+//
+//            limit {
+//                counter = 'INSTRUCTION'
+//                value = 'COVEREDRATIO'
+//                minimum = 0.50
+//            }
+//
+//            includes = ['*.domain.*']
+//        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jul 23 12:38:18 KST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/underdogs/devbie/MvcTest.java
+++ b/src/test/java/underdogs/devbie/MvcTest.java
@@ -16,32 +16,32 @@ public abstract class MvcTest {
 
     protected ResultActions getAction(String url) throws Exception {
         return this.mockMvc
-                .perform(get(url)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON));
+            .perform(get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 
     protected ResultActions getAction(String url, String bearerToken) throws Exception {
         return this.mockMvc
-                .perform(get(url)
-                        .header(AUTH_HEADER, bearerToken)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON));
+            .perform(get(url)
+                .header(AUTH_HEADER, bearerToken)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 
     protected ResultActions postAction(String url) throws Exception {
         return this.mockMvc
-                .perform(post(url)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON));
+            .perform(post(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 
     protected ResultActions postAction(String url, String inputJson, String bearerToken) throws Exception {
         return this.mockMvc
-                .perform(post(url)
-                        .header(AUTH_HEADER, bearerToken)
-                        .content(inputJson)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON));
+            .perform(post(url)
+                .header(AUTH_HEADER, bearerToken)
+                .content(inputJson)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON));
     }
 }

--- a/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
@@ -1,0 +1,96 @@
+package underdogs.devbie.acceptance;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+abstract class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    private static RequestSpecification given() {
+        return RestAssured.given().log().all();
+    }
+
+    protected <T> void post(String path, Map<String, String> params) {
+        // @formatter:off
+        given().
+                body(params).
+                contentType(MediaType.APPLICATION_JSON_VALUE).
+                accept(MediaType.APPLICATION_JSON_VALUE).
+        when().
+                post(path).
+        then().
+                log().all().
+                statusCode(HttpStatus.CREATED.value());
+        // @formatter:on
+    }
+
+    protected <T> T get(String path, Class<T> responseType) {
+        // @formatter:off
+        return
+            given().
+            when().
+                    get(path).
+            then().
+                    log().all().
+                    statusCode(HttpStatus.OK.value()).
+                    extract().as(responseType);
+        // @formatter:on
+    }
+
+    protected <T> List<T> getAll(String path, Class<T> responseType) {
+        // @formatter:off
+        return
+            given().
+            when().
+                    get(path).
+            then().
+                    log().all().
+                    statusCode(HttpStatus.OK.value()).
+                    extract().
+                    jsonPath().
+                    getList(".", responseType);
+        // @formatter:on
+    }
+
+    protected <T> void put(String path, Map<String, String> params) {
+        // @formatter:off
+        given().
+                body(params).
+                contentType(MediaType.APPLICATION_JSON_VALUE).
+                accept(MediaType.APPLICATION_JSON_VALUE).
+        when().
+                put(path).
+        then().
+                log().all().
+                statusCode(HttpStatus.OK.value());
+        // @formatter:on
+    }
+
+    protected <T> void delete(String path) {
+        // @formatter:off
+        given().
+        when().
+                delete(path).
+        then().
+                log().all().
+                statusCode(HttpStatus.NO_CONTENT.value());
+        // @formatter:on
+    }
+}

--- a/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
@@ -1,7 +1,6 @@
 package underdogs.devbie.acceptance;
 
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,10 +26,10 @@ abstract class AcceptanceTest {
         return RestAssured.given().log().all();
     }
 
-    protected <T> void post(String path, Map<String, String> params) {
+    protected <T> void post(String path, String inputJson) {
         // @formatter:off
         given().
-                body(params).
+                body(inputJson).
                 contentType(MediaType.APPLICATION_JSON_VALUE).
                 accept(MediaType.APPLICATION_JSON_VALUE).
         when().
@@ -69,10 +68,10 @@ abstract class AcceptanceTest {
         // @formatter:on
     }
 
-    protected <T> void put(String path, Map<String, String> params) {
+    protected <T> void put(String path, String inputJson) {
         // @formatter:off
         given().
-                body(params).
+                body(inputJson).
                 contentType(MediaType.APPLICATION_JSON_VALUE).
                 accept(MediaType.APPLICATION_JSON_VALUE).
         when().

--- a/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/acceptance/AcceptanceTest.java
@@ -82,6 +82,20 @@ abstract class AcceptanceTest {
         // @formatter:on
     }
 
+    protected <T> void patch(String path, String inputJson) {
+        // @formatter:off
+        given().
+                body(inputJson).
+                contentType(MediaType.APPLICATION_JSON_VALUE).
+                accept(MediaType.APPLICATION_JSON_VALUE).
+        when().
+                patch(path).
+        then().
+                log().all().
+                statusCode(HttpStatus.OK.value());
+        // @formatter:on
+    }
+
     protected <T> void delete(String path) {
         // @formatter:off
         given().

--- a/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
+++ b/src/test/java/underdogs/devbie/auth/controller/AuthControllerTest.java
@@ -40,9 +40,9 @@ public class AuthControllerTest extends MvcTest {
         String url = "/api/auth/login-url";
 
         getAction(url)
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(TEST_LOGIN_URL)))
-                .andDo(print());
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(TEST_LOGIN_URL)))
+            .andDo(print());
     }
 
     @DisplayName("로그인")
@@ -53,8 +53,8 @@ public class AuthControllerTest extends MvcTest {
         String url = "/api/auth/login" + "?code=" + TEST_CODE;
 
         postAction(url)
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString(TEST_TOKEN)))
-                .andDo(print());
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(TEST_TOKEN)))
+            .andDo(print());
     }
 }

--- a/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
+++ b/src/test/java/underdogs/devbie/user/service/UserServiceTest.java
@@ -33,7 +33,7 @@ class UserServiceTest {
     @DisplayName("Oauth로부터 User 모델 신규 저장 및 업데이트")
     @Test
     void saveOrUpdateOauthUser() {
-        User mockUser =  User.builder()
+        User mockUser = User.builder()
             .id(1L)
             .oauthId(TEST_OAUTH_ID)
             .email(TEST_USER_EMAIL)
@@ -53,7 +53,7 @@ class UserServiceTest {
     @DisplayName("Id로 유저 조회")
     @Test
     void findById() {
-        User mockUser =  User.builder()
+        User mockUser = User.builder()
             .id(1L)
             .oauthId(TEST_OAUTH_ID)
             .email(TEST_USER_EMAIL)


### PR DESCRIPTION
## Resolve #60 

- Acceptance Test 작성할 때 필요한 CRUD 요청을 위한 편의 메서드가 필요하다.

## Changes

- post, get, getAll, put, delete 편의 메서드 생성

## Notes

- parameter를 넣을 때 DTO를 직렬화 후 String으로 넣어야 한다.

## References

- N/A