### PR TITLE
feat: jacoco coverage 및 lombok 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.50
+                minimum = 0.60
             }
 
             includes = ['*.domain.*']

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+


### PR DESCRIPTION
## Resolve #62 

- jacoco가 lombok 메서드를 테스트하고 있어서 커버리지가 낮게 나옴.

## Changes

- INSTRUCTION coverage 60%
- lombok 으로 생성되는 메서드는 테스트 제외하도록 lombok.confg 파일추가

## Notes

- 현재는 Repository 테스트를 안하는 것(직접 쿼리 작성하는것 제외)으로 결정했기 때문에 domain 패키지의 커버리지가 낮아지는 것을 감안해야함.
- 추후 Repository 테스트 여부와 커버리지 하향 추이를 보고 jacoco 커버리지를 0.6에서 0.7~8로 올릴 예정.

## References

- [Jacoco not ignoring Lombok](https://github.com/jacoco/jacoco/issues/643)
