### PR TITLE
refactor: Notice 엔티티에 title,noticeType 필드 추가

### DIFF
--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -28,6 +28,13 @@ public class Notice extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NoticeType noticeType;
+
     @Embedded
     @Column(nullable = false)
     private Company company;
@@ -48,10 +55,13 @@ public class Notice extends BaseTimeEntity {
     private String image;
 
     @Builder
-    private Notice(Long id, Company company, Duration duration, JobPosition jobPosition,
+    private Notice(Long id, String title, NoticeType noticeType, Company company, Duration duration,
+        JobPosition jobPosition,
         NoticeDescription noticeDescription, String image) {
-        validateParameters(company, jobPosition, noticeDescription);
+        validateParameters(title, noticeType, company, jobPosition, noticeDescription);
         this.id = id;
+        this.title = title;
+        this.noticeType = noticeType;
         this.company = company;
         this.duration = duration;
         this.jobPosition = jobPosition;
@@ -59,9 +69,11 @@ public class Notice extends BaseTimeEntity {
         this.image = image;
     }
 
-    private void validateParameters(Company company, JobPosition jobPosition,
+    private void validateParameters(String title, NoticeType noticeType, Company company, JobPosition jobPosition,
         NoticeDescription noticeDescription) {
-        if (Objects.isNull(company)
+        if (Objects.isNull(title)
+            || Objects.isNull(noticeType)
+            || Objects.isNull(company)
             || Objects.isNull(jobPosition)
             || Objects.isNull(noticeDescription)) {
             throw new CreateFailException();
@@ -69,6 +81,8 @@ public class Notice extends BaseTimeEntity {
     }
 
     public void update(Notice notice) {
+        this.title = notice.title;
+        this.noticeType = notice.noticeType;
         this.company = notice.company;
         this.duration = notice.duration;
         this.jobPosition = notice.jobPosition;

--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -20,7 +20,6 @@ import underdogs.devbie.notice.expception.CreateFailException;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @Getter
 public class Notice extends BaseTimeEntity {
 

--- a/src/main/java/underdogs/devbie/notice/domain/NoticeType.java
+++ b/src/main/java/underdogs/devbie/notice/domain/NoticeType.java
@@ -1,0 +1,6 @@
+package underdogs.devbie.notice.domain;
+
+public enum NoticeType {
+
+    JOB, EDUCATION
+}

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeCreateRequest.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeCreateRequest.java
@@ -19,6 +19,7 @@ import underdogs.devbie.notice.domain.Duration;
 import underdogs.devbie.notice.domain.JobPosition;
 import underdogs.devbie.notice.domain.Notice;
 import underdogs.devbie.notice.domain.NoticeDescription;
+import underdogs.devbie.notice.domain.NoticeType;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -30,6 +31,11 @@ public class NoticeCreateRequest {
     private String startDate;
 
     private String endDate;
+
+    @NotBlank
+    private String title;
+
+    private NoticeType noticeType;
 
     @NotBlank
     private String name;
@@ -52,6 +58,8 @@ public class NoticeCreateRequest {
         LocalDateTime endLocalDate = LocalDateTime.parse(endDate);
 
         return Notice.builder()
+            .title(title)
+            .noticeType(noticeType)
             .company(new Company(name, salary))
             .duration(new Duration(startLocalDate, endLocalDate))
             .jobPosition(jobPosition)

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeDetailResponse.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeDetailResponse.java
@@ -9,6 +9,7 @@ import underdogs.devbie.notice.domain.Company;
 import underdogs.devbie.notice.domain.Duration;
 import underdogs.devbie.notice.domain.JobPosition;
 import underdogs.devbie.notice.domain.Notice;
+import underdogs.devbie.notice.domain.NoticeType;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,6 +19,8 @@ public class NoticeDetailResponse {
 
     private Long id;
     private Company company;
+    private String title;
+    private NoticeType noticeType;
     private Duration duration;
     private JobPosition jobPosition;
     private NoticeDescriptionResponse noticeDescription;
@@ -27,6 +30,8 @@ public class NoticeDetailResponse {
         return NoticeDetailResponse.builder()
             .id(notice.getId())
             .company(notice.getCompany())
+            .title(notice.getTitle())
+            .noticeType(notice.getNoticeType())
             .noticeDescription(NoticeDescriptionResponse.from(notice.getNoticeDescription()))
             .jobPosition(notice.getJobPosition())
             .image(notice.getImage())

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeResponse.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import underdogs.devbie.notice.domain.JobPosition;
+import underdogs.devbie.notice.domain.NoticeType;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,6 +18,8 @@ public class NoticeResponse {
 
     private Long id;
     private String name;
+    private String title;
+    private NoticeType noticeType;
     private Set<String> languages;
     private JobPosition jobPosition;
     private String image;

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeResponses.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeResponses.java
@@ -25,6 +25,8 @@ public class NoticeResponses {
             .map(notice -> NoticeResponse.builder()
                 .id(notice.getId())
                 .name(notice.getCompany().getName())
+                .title(notice.getTitle())
+                .noticeType(notice.getNoticeType())
                 .image(notice.getImage())
                 .languages(collectLanguageName(notice))
                 .jobPosition(notice.getJobPosition())

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeUpdateRequest.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeUpdateRequest.java
@@ -19,6 +19,7 @@ import underdogs.devbie.notice.domain.Duration;
 import underdogs.devbie.notice.domain.JobPosition;
 import underdogs.devbie.notice.domain.Notice;
 import underdogs.devbie.notice.domain.NoticeDescription;
+import underdogs.devbie.notice.domain.NoticeType;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -30,6 +31,11 @@ public class NoticeUpdateRequest {
     private String startDate;
 
     private String endDate;
+
+    @NotBlank
+    private String title;
+
+    private NoticeType noticeType;
 
     @NotBlank
     private String name;
@@ -53,6 +59,8 @@ public class NoticeUpdateRequest {
 
         return Notice.builder()
             .id(id)
+            .title(title)
+            .noticeType(noticeType)
             .company(new Company(name, salary))
             .duration(new Duration(startLocalDate, endLocalDate))
             .jobPosition(jobPosition)

--- a/src/main/java/underdogs/devbie/recommendation/dto/RecommendationResponse.java
+++ b/src/main/java/underdogs/devbie/recommendation/dto/RecommendationResponse.java
@@ -8,14 +8,17 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import underdogs.devbie.recommendation.domain.AnswerRecommendation;
 import underdogs.devbie.recommendation.domain.QuestionRecommendation;
 import underdogs.devbie.recommendation.domain.Recommendation;
 import underdogs.devbie.recommendation.domain.RecommendationType;
 
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class RecommendationResponse {
 

--- a/src/test/java/underdogs/devbie/notice/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/notice/acceptance/NoticeAcceptanceTest.java
@@ -17,6 +17,7 @@ import underdogs.devbie.notice.domain.Company;
 import underdogs.devbie.notice.domain.Duration;
 import underdogs.devbie.notice.domain.JobPosition;
 import underdogs.devbie.notice.domain.Language;
+import underdogs.devbie.notice.domain.NoticeType;
 import underdogs.devbie.notice.dto.NoticeCreateRequest;
 import underdogs.devbie.notice.dto.NoticeDetailResponse;
 import underdogs.devbie.notice.dto.NoticeResponse;
@@ -57,6 +58,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
     void notice() throws JsonProcessingException {
         NoticeCreateRequest noticeCreateRequest = NoticeCreateRequest.builder()
             .name("underdogs")
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .salary(50_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName()))
             .jobPosition(JobPosition.BACKEND)
@@ -68,6 +71,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
 
         NoticeUpdateRequest noticeUpdateRequest = NoticeUpdateRequest.builder()
             .name("bossdog")
+            .title("우테코 모집")
+            .noticeType(NoticeType.EDUCATION)
             .salary(60_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName(), Language.CPP.getName()))
             .jobPosition(JobPosition.FRONTEND)

--- a/src/test/java/underdogs/devbie/notice/acceptance/NoticeAcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/notice/acceptance/NoticeAcceptanceTest.java
@@ -109,6 +109,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(noticeResponse.getId()).isEqualTo(1L),
             () -> assertThat(noticeResponse.getName()).isEqualTo("underdogs"),
+            () -> assertThat(noticeResponse.getTitle()).isEqualTo("언더독스 채용"),
+            () -> assertThat(noticeResponse.getNoticeType()).isEqualTo(NoticeType.JOB),
             () -> assertThat(noticeResponse.getImage()).isEqualTo("/static/image/underdogs"),
             () -> assertThat(noticeResponse.getJobPosition()).isEqualTo(JobPosition.BACKEND),
             () -> assertThat(noticeResponse.getLanguages()).contains(Language.JAVA.getName(),
@@ -122,6 +124,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(result.getId()).isEqualTo(1L),
             () -> assertThat(result.getCompany()).isEqualTo(new Company("bossdog", 60_000_000)),
+            () -> assertThat(result.getTitle()).isEqualTo("우테코 모집"),
+            () -> assertThat(result.getNoticeType()).isEqualTo(NoticeType.EDUCATION),
             () -> assertThat(result.getJobPosition()).isEqualTo(JobPosition.FRONTEND),
             () -> assertThat(result.getImage()).isEqualTo("/static/image/bossdog"),
             () -> assertThat(result.getNoticeDescription().getContent()).isEqualTo("You are hired!"),

--- a/src/test/java/underdogs/devbie/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/underdogs/devbie/notice/controller/NoticeControllerTest.java
@@ -31,6 +31,7 @@ import underdogs.devbie.notice.domain.JobPosition;
 import underdogs.devbie.notice.domain.Language;
 import underdogs.devbie.notice.domain.Notice;
 import underdogs.devbie.notice.domain.NoticeDescription;
+import underdogs.devbie.notice.domain.NoticeType;
 import underdogs.devbie.notice.dto.NoticeCreateRequest;
 import underdogs.devbie.notice.dto.NoticeDescriptionResponse;
 import underdogs.devbie.notice.dto.NoticeDetailResponse;
@@ -64,6 +65,8 @@ public class NoticeControllerTest extends MvcTest {
 
         noticeCreateRequest = NoticeCreateRequest.builder()
             .name("underdogs")
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .salary(50_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName()))
             .jobPosition(JobPosition.BACKEND)
@@ -75,6 +78,8 @@ public class NoticeControllerTest extends MvcTest {
 
         noticeUpdateRequest = NoticeUpdateRequest.builder()
             .name("underdogs")
+            .title("우테코 모집")
+            .noticeType(NoticeType.EDUCATION)
             .salary(50_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName()))
             .jobPosition(JobPosition.BACKEND)
@@ -181,6 +186,8 @@ public class NoticeControllerTest extends MvcTest {
     void readAll() throws Exception {
         List<Notice> notices = Arrays.asList(Notice.builder()
             .id(1L)
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .company(new Company("underdogs", 2000))
             .image("/static/image/underdogs")
             .jobPosition(JobPosition.BACKEND)

--- a/src/test/java/underdogs/devbie/notice/domain/NoticeTest.java
+++ b/src/test/java/underdogs/devbie/notice/domain/NoticeTest.java
@@ -20,6 +20,8 @@ public class NoticeTest {
             .collect(Collectors.toSet());
         Notice notice = Notice.builder()
             .id(1L)
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .company(new Company("underdogs", 50_000_000))
             .jobPosition(JobPosition.BACKEND)
             .noticeDescription(new NoticeDescription(languages, "We are hiring!"))
@@ -33,6 +35,8 @@ public class NoticeTest {
         JobPosition expectedJobPosition = JobPosition.FRONTEND;
         Notice updatedNotice = Notice.builder()
             .id(1L)
+            .title("우테코 모집")
+            .noticeType(NoticeType.EDUCATION)
             .company(expectedCompany)
             .noticeDescription(expectedDetail)
             .image(expectedImage)

--- a/src/test/java/underdogs/devbie/notice/service/NoticeServiceTest.java
+++ b/src/test/java/underdogs/devbie/notice/service/NoticeServiceTest.java
@@ -26,6 +26,7 @@ import underdogs.devbie.notice.domain.Language;
 import underdogs.devbie.notice.domain.Notice;
 import underdogs.devbie.notice.domain.NoticeDescription;
 import underdogs.devbie.notice.domain.NoticeRepository;
+import underdogs.devbie.notice.domain.NoticeType;
 import underdogs.devbie.notice.dto.NoticeCreateRequest;
 import underdogs.devbie.notice.dto.NoticeDetailResponse;
 import underdogs.devbie.notice.dto.NoticeResponse;
@@ -51,6 +52,8 @@ public class NoticeServiceTest {
             .collect(Collectors.toSet());
         Notice expected = Notice.builder()
             .id(1L)
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .company(new Company("underdogs", 50_000_000))
             .jobPosition(JobPosition.BACKEND)
             .noticeDescription(new NoticeDescription(languages, "We are hiring!"))
@@ -61,6 +64,8 @@ public class NoticeServiceTest {
 
         NoticeCreateRequest noticeRequest = NoticeCreateRequest.builder()
             .name("underdogs")
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .salary(50_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName()))
             .jobPosition(JobPosition.BACKEND)
@@ -81,6 +86,8 @@ public class NoticeServiceTest {
         Long id = 2L;
         NoticeUpdateRequest request = NoticeUpdateRequest.builder()
             .name("underdogs")
+            .title("우테코 모집")
+            .noticeType(NoticeType.EDUCATION)
             .salary(50_000_000)
             .languages(Arrays.asList(Language.JAVA.getName(), Language.JAVASCRIPT.getName()))
             .jobPosition(JobPosition.BACKEND)
@@ -114,6 +121,8 @@ public class NoticeServiceTest {
             .collect(Collectors.toSet());
         Notice expected = Notice.builder()
             .id(1L)
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .company(new Company("underdogs", 50_000_000))
             .jobPosition(JobPosition.BACKEND)
             .noticeDescription(new NoticeDescription(languages, "We are hiring!"))
@@ -143,6 +152,8 @@ public class NoticeServiceTest {
             .collect(Collectors.toSet());
         Notice expected = Notice.builder()
             .id(1L)
+            .title("언더독스 채용")
+            .noticeType(NoticeType.JOB)
             .company(new Company("underdogs", 50_000_000))
             .jobPosition(JobPosition.BACKEND)
             .noticeDescription(new NoticeDescription(languages, "We are hiring!"))


### PR DESCRIPTION
## Resolve #87 

- Notice 엔티티에 필요한 필드 중 제목(title)과 공고 타입(채용/교육)이 누락되어 추가가 필요하다.

## Changes

-  Notice 엔티티에 title, noticeType 필드를 추가
- 관련 테스트 코드를 수정 및 추가

## Notes

- N/A

## References

- N/A
