### PR TITLE
bugfix: POST요청시, 컨트롤러의 파라미터 로깅이 누락되는 문제 해결

### DIFF
--- a/src/main/java/underdogs/devbie/aop/ControllerLoggingAspect.java
+++ b/src/main/java/underdogs/devbie/aop/ControllerLoggingAspect.java
@@ -29,33 +29,27 @@ class ControllerLoggingAspect {
 
     @Around("loggerPointCut()")
     public Object methodLogger(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object result = proceedingJoinPoint.proceed();
+        HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest();
+
+        String controllerName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = proceedingJoinPoint.getSignature().getName();
+
+        Map<String, Object> params = new HashMap<>();
+
         try {
-            Object result = proceedingJoinPoint.proceed();
-            HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest();
-
-            String controllerName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
-            String methodName = proceedingJoinPoint.getSignature().getName();
-
-            Map<String, Object> params = new HashMap<>();
-
-            try {
-                params.put("controller", controllerName);
-                params.put("method", methodName);
-                params.put("params", getParams(request));
-                params.put("log_time", new Date());
-                params.put("request_uri", request.getRequestURI());
-                params.put("http_method", request.getMethod());
-            } catch (Exception e) {
-                log.error("ControllerLoggerAspect error", e);
-            }
-            log.info("params : {}", params);
-
-            return result;
-
-        } catch (Throwable throwable) {
-            log.error("AOP proceeding error", throwable);
-            throw throwable;
+            params.put("controller", controllerName);
+            params.put("method", methodName);
+            params.put("params", getParams(request));
+            params.put("log_time", new Date());
+            params.put("request_uri", request.getRequestURI());
+            params.put("http_method", request.getMethod());
+        } catch (Exception e) {
+            log.error("LoggingAspect error", e);
         }
+
+        log.info("params : {}", params);
+        return result;
     }
 
     private static JSONObject getParams(HttpServletRequest request) {

--- a/src/main/java/underdogs/devbie/aop/ServiceLoggingAspect.java
+++ b/src/main/java/underdogs/devbie/aop/ServiceLoggingAspect.java
@@ -24,29 +24,23 @@ public class ServiceLoggingAspect {
 
     @Around("loggerPointCut()")
     public Object methodLogger(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object result = proceedingJoinPoint.proceed();
+
+        String serviceName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = proceedingJoinPoint.getSignature().getName();
+
+        Map<String, Object> params = new HashMap<>();
+
         try {
-            Object result = proceedingJoinPoint.proceed();
-
-            String serviceName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
-            String methodName = proceedingJoinPoint.getSignature().getName();
-
-            Map<String, Object> params = new HashMap<>();
-
-            try {
-                params.put("service", serviceName);
-                params.put("method", methodName);
-                params.put("params", Arrays.toString(proceedingJoinPoint.getArgs()));
-                params.put("log_time", new Date());
-            } catch (Exception e) {
-                log.error("LoggerAspect error", e);
-            }
-            log.info("params : {}", params);
-
-            return result;
-
-        } catch (Throwable throwable) {
-            log.error("AOP proceeding error", throwable);
-            throw throwable;
+            params.put("service", serviceName);
+            params.put("method", methodName);
+            params.put("params", Arrays.toString(proceedingJoinPoint.getArgs()));
+            params.put("log_time", new Date());
+        } catch (Exception e) {
+            log.error("LoggingAspect error", e);
         }
+
+        log.info("params : {}", params);
+        return result;
     }
 }

--- a/src/main/java/underdogs/devbie/filter/ReadableRequestWrapperFilter.java
+++ b/src/main/java/underdogs/devbie/filter/ReadableRequestWrapperFilter.java
@@ -31,11 +31,13 @@ import org.apache.http.entity.ContentType;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @WebFilter(urlPatterns = "/*")
+@Component
+@Slf4j
 public class ReadableRequestWrapperFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) {
@@ -67,7 +69,6 @@ public class ReadableRequestWrapperFilter implements Filter {
             try {
                 InputStream is = request.getInputStream();
                 this.rawData = IOUtils.toByteArray(is);
-
                 String collect = this.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
                 if (StringUtils.isEmpty(collect)) {
                     return;


### PR DESCRIPTION
## Resolve #112 

- POST요청 시, 컨트롤러의 파라미터 로깅이 누락되고있다.
- Request 요청이 Filter를 제대로 통과하지 못하고있다.

## Changes

- Filter를 컴포넌트로 등록
- 불필요한 try-catch문 삭제

## Notes

- N/A

## References

- N/A
