### PR TITLE
fix: router-link가 붙은 버튼을 두 번이상 클릭시 에러 생기는 문제 해결

### DIFF
--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -12,6 +12,14 @@ import NoticeDetail from "../components/notice/NoticeDetail";
 
 Vue.use(VueRouter);
 
+const originalPush = VueRouter.prototype.push;
+VueRouter.prototype.push = function push(location) {
+  return originalPush.call(this, location).catch(err => {
+    window.location.reload();
+    return err;
+  });
+};
+
 export const router = new VueRouter({
   mode: "history",
   routes: [


### PR DESCRIPTION
## Resolve #136 

-  router-link가 붙은 버튼을 두 번이상 클릭시 콘솔에 navigation관련 에러가 찍힌다.

## Changes

- 클릭할 때마다 reload 되게끔 개선

## Notes

- N/A

## References

- [Avoid Redundant Navigation](https://blog.csdn.net/qq_35432904/article/details/106786823)
