### PR TITLE
fix: 불필요한 fetch 삭제 및 fetch 파라미터 추가

### DIFF
--- a/src/frontend/src/components/notice/NoticeDetail.vue
+++ b/src/frontend/src/components/notice/NoticeDetail.vue
@@ -68,7 +68,6 @@ import { mapGetters } from "vuex";
 export default {
   created() {
     const noticeId = this.$route.params.id;
-    this.$store.dispatch("FETCH_NOTICES");
     this.$store.dispatch("FETCH_NOTICE", noticeId);
   },
   computed: {

--- a/src/frontend/src/components/notice/NoticeScroll.vue
+++ b/src/frontend/src/components/notice/NoticeScroll.vue
@@ -58,10 +58,22 @@ export default {
     };
   },
   created() {
-    this.$store.dispatch("FETCH_NOTICES");
+    const param = {
+      noticeType: this.fetchedNoticeType,
+      jobPosition: this.fetchedJobPosition,
+      language: this.fetchedLanguage
+    };
+    const queryParam = new URLSearchParams(param).toString();
+
+    this.$store.dispatch("FETCH_NOTICES", queryParam);
   },
   computed: {
-    ...mapGetters(["fetchedNotices"]),
+    ...mapGetters([
+      "fetchedNotices",
+      "fetchedNoticeType",
+      "fetchedJobPosition",
+      "fetchedLanguage"
+    ]),
     items() {
       return this.fetchedNotices.noticeResponses;
     }


### PR DESCRIPTION
## Resolve #141

- NoticeScroll에서 전체채용공고를 불러오는데, 400에러가 발생한다.

## Changes

- 채용공고 검색에 필수파라미터가 빠져 추가했습니다.

## Notes

- 버그가 생긴이유는 서버에서 API를 수정했는데, 프론트에 적용을 못한부분이 있었습니다.
- NoticeDetail은 불필요한 공고전체를 가져와서 제거했습니다.

## References

- N/A
