### PR TITLE
hotfix: getters로 받아온 해시태그 데이터를 string 만 추출해야한다.

### DIFF
--- a/src/frontend/src/components/question/QuestionEdit.vue
+++ b/src/frontend/src/components/question/QuestionEdit.vue
@@ -69,14 +69,14 @@ export default {
     fetchedLoginUser() {
       this.title = this.fetchedQuestion.title;
       this.content = this.fetchedQuestion.content;
-      this.hashtags = this.fetchedQuestion.hashtags;
+      this.hashtags = this.fetchedQuestion.hashtags.map(h => h.tagName);
     }
   },
   async created() {
     await this.$store.dispatch("FETCH_QUESTION", this.questionId);
     this.title = this.fetchedQuestion.title;
     this.content = this.fetchedQuestion.content;
-    this.hashtags = this.fetchedQuestion.hashtags;
+    this.hashtags = this.fetchedQuestion.hashtags.map(h => h.tagName);
   },
   components: {
     HashtagBox,


### PR DESCRIPTION
## Resolve #153 

## Changes

- 프론트에서 화면에 객체를 뿌릴때, tagName만 추출해서 올린다. (현재는 id까지 포함된 객체가 올라간다.)

## Notes

- N/A

## References

- N/A
