### PR TITLE
feat: 공고 이미지 업로드 기능추가

### DIFF
--- a/src/frontend/src/api/index.js
+++ b/src/frontend/src/api/index.js
@@ -15,10 +15,11 @@ function getAction(url) {
   });
 }
 
-function postAction(url, request) {
+function postAction(url, request, configOption) {
   return axios.post(`${config.baseUrl}${url}`, request, {
     headers: {
-      Authorization: devbieToken
+      Authorization: devbieToken,
+      ...configOption
     }
   });
 }

--- a/src/frontend/src/components/notice/NoticeDetail.vue
+++ b/src/frontend/src/components/notice/NoticeDetail.vue
@@ -13,10 +13,12 @@
             <div class="notice-img">
               <v-img
                 :src="
-                  'https://images.velog.io/images/sonypark/post/80241b72-4ffe-4223-a775-41c34dd6aed7/woowa-dev.jpeg'
+                  fetchedNotice.image === null
+                    ? 'https://images.velog.io/images/sonypark/post/80241b72-4ffe-4223-a775-41c34dd6aed7/woowa-dev.jpeg'
+                    : fetchedNotice.image
                 "
                 class="white--text align-end"
-                height="200px"
+                max-width="300px"
               >
               </v-img>
             </div>

--- a/src/frontend/src/store/modules/notices.js
+++ b/src/frontend/src/store/modules/notices.js
@@ -63,11 +63,7 @@ export default {
     },
     async CREATE_NOTICE({ commit }, noticeRequest) {
       try {
-        const temp = {
-          ...noticeRequest,
-          image: noticeRequest.image.name
-        };
-        const response = await postAction(`/api/notices`, temp);
+        const response = await postAction(`/api/notices`, noticeRequest);
         const id = response["headers"].location.split("/")[3];
         commit("SET_NOTICE_ID", id);
       } catch (error) {
@@ -86,6 +82,19 @@ export default {
       try {
         await patchAction(`/api/notices/${id}`, params);
         commit("UPDATE_NOTICE", id, params);
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    // eslint-disable-next-line no-unused-vars
+    async UPLOAD_NOTICE_IMAGE({ commit }, payload) {
+      try {
+        const response = await postAction(
+          `/api/notices/image`,
+          payload,
+          `content-type: multipart/form-data`
+        );
+        return response["headers"].location;
       } catch (error) {
         console.log(error);
       }

--- a/src/frontend/src/views/notice/NoticeCreateView.vue
+++ b/src/frontend/src/views/notice/NoticeCreateView.vue
@@ -55,7 +55,7 @@
         label="연봉"
         required
       ></v-text-field>
-      <v-file-input label="사진" filled v-model="request.image"> </v-file-input>
+      <input type="file" ref="image" @change="imageUpload" />
       <v-textarea
         outlined
         v-model="request.description"
@@ -126,6 +126,24 @@ export default {
       const fetchedLoginUser = await this.$store.getters.fetchedLoginUser;
       if (fetchedLoginUser === null || fetchedLoginUser.roleType !== "ADMIN") {
         await this.$router.push("/");
+      }
+    },
+    async imageUpload() {
+      const image_files = this.$refs.image.files[0];
+      if (!image_files) {
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("image", image_files);
+
+      try {
+        this.request.image = await this.$store.dispatch(
+          "UPLOAD_NOTICE_IMAGE",
+          formData
+        );
+      } catch (e) {
+        console.error(e);
       }
     },
     async submit() {

--- a/src/frontend/src/views/notice/NoticeEditView.vue
+++ b/src/frontend/src/views/notice/NoticeEditView.vue
@@ -32,20 +32,16 @@
         required
       ></v-text-field>
       <div class="duration">
-        <v-text-field
+        <input
+          aria-label="시작일"
           v-model="request.startDate"
-          placeholder="2010-10-20 13:00"
-          :rules="textRules"
-          label="시작일"
-          required
-        ></v-text-field>
-        <v-text-field
+          type="datetime-local"
+        />
+        <input
+          aria-labelledby="종료일"
           v-model="request.endDate"
-          placeholder="2010-10-20 14:00"
-          :rules="textRules"
-          label="종료일"
-          required
-        ></v-text-field>
+          type="datetime-local"
+        />
       </div>
       <v-text-field
         v-model="request.name"
@@ -59,7 +55,7 @@
         label="연봉"
         required
       ></v-text-field>
-      <v-file-input label="사진" filled v-model="request.image"> </v-file-input>
+      <input type="file" ref="image" @change="imageUpload" />
       <v-textarea
         outlined
         v-model="request.description"
@@ -146,6 +142,24 @@ export default {
   },
 
   methods: {
+    async imageUpload() {
+      const image_files = this.$refs.image.files[0];
+      if (!image_files) {
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("image", image_files);
+
+      try {
+        this.request.image = await this.$store.dispatch(
+          "UPLOAD_NOTICE_IMAGE",
+          formData
+        );
+      } catch (e) {
+        console.error(e);
+      }
+    },
     async isAdmin() {
       const fetchedLoginUser = await this.$store.getters.fetchedLoginUser;
       if (fetchedLoginUser === null || fetchedLoginUser.roleType !== "ADMIN") {

--- a/src/main/java/underdogs/devbie/notice/dto/ImageUploadRequest.java
+++ b/src/main/java/underdogs/devbie/notice/dto/ImageUploadRequest.java
@@ -1,0 +1,25 @@
+package underdogs.devbie.notice.dto;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@Setter
+@ToString
+public class ImageUploadRequest {
+
+    @NotNull
+    private MultipartFile image;
+}

--- a/src/main/java/underdogs/devbie/notice/dto/NoticeCreateRequest.java
+++ b/src/main/java/underdogs/devbie/notice/dto/NoticeCreateRequest.java
@@ -8,7 +8,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -55,7 +54,6 @@ public class NoticeCreateRequest {
     @NotBlank
     private String description;
 
-    @JsonProperty("image")
     private String image;
 
     public Notice toEntity() {

--- a/src/test/java/underdogs/devbie/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/underdogs/devbie/notice/controller/NoticeControllerTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import underdogs.devbie.MvcTest;
 import underdogs.devbie.auth.controller.interceptor.BearerAuthInterceptor;
 import underdogs.devbie.auth.controller.resolver.LoginUserArgumentResolver;
+import underdogs.devbie.aws.S3Service;
 import underdogs.devbie.notice.domain.Company;
 import underdogs.devbie.notice.domain.Duration;
 import underdogs.devbie.notice.domain.JobPosition;
@@ -49,6 +50,9 @@ public class NoticeControllerTest extends MvcTest {
 
     @MockBean
     private NoticeService noticeService;
+
+    @MockBean
+    private S3Service s3Service;
 
     @MockBean
     private BearerAuthInterceptor bearerAuthInterceptor;


### PR DESCRIPTION
## Resolve #157

- 채용공고의 이미지업로드 기능이 필요하다.

## Changes

- 프론트엔드 및 백엔드의  연동과정이 있었다.

## Notes

- 추후 업로드 기능을 단일화해서, 프로필사진 변경 및 공고 업로드에서 1개의 메서드로 처리한다.
- 이미지 업로드 중 사용자가 저장을 완료하면 안되는 것에 대한 validation이 필요함.

## References

- @sonypark 