### PR TITLE
refactor: page transition fade로 변경

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app id="app">
     <navigation-bar @logout="logout"></navigation-bar>
-    <transition name="page">
+    <transition name="fade">
       <router-view :key="$route.fullPath" class="content"></router-view>
     </transition>
     <chat-drawer></chat-drawer>

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -54,13 +54,13 @@ a {
   text-decoration: none;
 }
 
-.page-enter-active,
-.page-leave-active {
-  transition: opacity 0.5s;
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.4s;
 }
 
-.page-enter,
-.page-leave-to {
+.fade-enter,
+.fade-leave-to {
   opacity: 0;
 }
 </style>

--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app id="app">
     <navigation-bar @logout="logout"></navigation-bar>
-    <transition name="fade">
+    <transition name="fade" mode="out-in">
       <router-view :key="$route.fullPath" class="content"></router-view>
     </transition>
     <chat-drawer></chat-drawer>


### PR DESCRIPTION
## Resolve #184 

- 라우팅할 때 transition이 page로 걸려있어서 로딩이 늦는 것 처럼 보인다.

## Changes

- transition의 name="fade"로 변경
- mode로 "out-in"추가

## Notes

- N/A

## References

- [routing transition #1](https://forum.vuejs.org/t/navigating-with-router-push-causes-page-to-jump-up-from-bottom/32706)
- [routing transition #2](https://forum.vuejs.org/t/vue-router-page-position-when-navigating-pages/32885/4)
