### PR TITLE
feat: 구글 애널리틱스 적용

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ branches:
     - master
     - develop
 
+env:
+  global:
+    - NODE_ENV=production
+
 before_install:
   - chmod +x gradlew
 
@@ -15,6 +19,4 @@ cache:
     - '$HOME/.m2/repository'
     - '$HOME/.gradle'
 
-script:
-  - "export NODE_ENV=production"
-  - "./gradlew clean build"
+script: "./gradlew clean build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ cache:
     - '$HOME/.m2/repository'
     - '$HOME/.gradle'
 
-script: "./gradlew clean build"
+script:
+  - "export NODE_ENV=production"
+  - "./gradlew clean build"

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -10794,6 +10794,11 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
+    "vue-analytics": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz",
+      "integrity": "sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ=="
+    },
     "vue-eslint-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -17,6 +17,7 @@
     "router": "^1.3.5",
     "sockjs-client": "^1.5.0",
     "vue": "^2.6.11",
+    "vue-analytics": "^5.22.1",
     "vue-router": "^3.3.4",
     "vuetify": "^2.3.4",
     "vuex": "^3.5.1",

--- a/src/frontend/src/main.js
+++ b/src/frontend/src/main.js
@@ -4,8 +4,19 @@ import vuetify from "./plugins/vuetify";
 import { router } from "./router";
 import { store } from "./store";
 import { editor } from "./utils/editor";
+import VueAnalytics from "vue-analytics";
+
+const isProd = process.env.NODE_ENV === "production";
 
 Vue.config.productionTip = false;
+Vue.use(VueAnalytics, {
+  id: "UA-176434466-1",
+  debug: {
+    enable: !isProd,
+    sendHitTask: isProd
+  },
+  router
+});
 
 new Vue({
   router,


### PR DESCRIPTION
## Resolve #204

- 웹사이트 사용자 통계가 필요하다

## Changes

- Vue에 필요한 의존성 추가
- 트래비스에서 프로덕션 환경에서 실행할 수 있도록 수정
- 

## Notes

- 첫 번째 레퍼런스 참고하니 로컬에서도 집계를 하더라구요. 그래서 두번 째 링크를 참고했습니다.
- [링크](https://analytics.google.com/analytics/web/provision/?hl=ko&pli=1#/provision)에서 집계를 확인할 수 있습니다. 구글 계정을 공유하겠습니다.

## References

- [가벼운예제](https://velog.io/@bluestragglr/Vue.js%EC%97%90-Google-Analytics-%EB%B6%99%EC%9D%B4%EA%B8%B0)
- [개발환경과 분리](https://medium.com/dailyjs/tips-tricks-for-vue-analytics-87a9d2838915)

