### PR TITLE
hotfix: 의도치 않은 disconnect 로그 제거

### DIFF
--- a/src/frontend/src/store/modules/chat.js
+++ b/src/frontend/src/store/modules/chat.js
@@ -23,6 +23,7 @@ function connectStomp(state) {
 function disconnect(state) {
   deleteAction("/api/chatrooms/" + state.name + "?noticeId=" + state.noticeId);
   state.stompClient.disconnect();
+  state.stompClient = null;
 }
 
 export default {


### PR DESCRIPTION
## Resolve #212 

- 채팅방 입장시 의도치 않은 오류메시지가 계속 나온다

## Changes

- disconnect와 connect시 기존의 stompClient가 있는지 확인하는 로직을 변경했다

