### PR TITLE
fix: 채팅방 이슈 해결

### DIFF
--- a/src/frontend/src/App.vue
+++ b/src/frontend/src/App.vue
@@ -36,6 +36,9 @@ export default {
       }
     }
   },
+  created() {
+    window.addEventListener("beforeunload", this.closeDrawer);
+  },
   methods: {
     logout() {
       localStorage.removeItem("devbieToken");
@@ -43,6 +46,9 @@ export default {
     },
     openDrawer() {
       this.$store.dispatch("OPEN_LATEST");
+    },
+    closeDrawer() {
+      this.$store.dispatch("CLOSE_DRAWER");
     }
   },
   computed: {

--- a/src/frontend/src/components/chat/ChatList.vue
+++ b/src/frontend/src/components/chat/ChatList.vue
@@ -16,6 +16,9 @@ export default {
   computed: {
     ...mapGetters(["fetchedChats"])
   },
+  mounted() {
+    this.$refs.chatList.$el.scrollTop = this.$refs.chatList.$el.scrollHeight;
+  },
   watch: {
     fetchedChats() {
       setTimeout(() => {


### PR DESCRIPTION
## Resolve #220 

- 채팅방 초기 로딩 시 스크롤이 맨 밑으로 가지 않는 경우가 있다
- 채팅방 강제 종료 시 인원 감소가 제대로 적용되지 않는 경우가 있다

## Changes

- mounted로 스크롤을 맨 아래로 가도록 했다
- beforeunload때 disconnect를 시켰다
