### PR TITLE
fix: 공고리스트 화면에서 로그아웃 기능 수정

### DIFF
--- a/src/frontend/src/components/notice/NoticeList.vue
+++ b/src/frontend/src/components/notice/NoticeList.vue
@@ -116,12 +116,6 @@ export default {
     await this.addNotices();
   },
 
-  mounted() {
-    if (!this.isLoggedIn) {
-      this.$store.commit("DELETE_NOTICE_FAVORITES");
-    }
-  },
-
   methods: {
     async onScroll({ target }) {
       if (!this.isReady) {
@@ -206,6 +200,10 @@ export default {
     },
 
     async initFavoriteState() {
+      if (!this.isLoggedIn) {
+        this.$store.commit("DELETE_NOTICE_FAVORITES");
+        return;
+      }
       await this.$store.dispatch("FETCH_LOGIN_USER");
       await this.$store.dispatch("FETCH_MY_FAVORITES", {
         userId: this.fetchedLoginUser.id,


### PR DESCRIPTION
## Resolve #224 

- 공고 리스트 화면에서 로그아웃이 정상적으로 동작하지 않는다.

## Changes

- 로그인 되었을 때만 FETCH_USER하도록 변경

## Notes

- N/A

## References

- 앨런
