### PR TITLE
fix: hashtag & answer subquery bug

### DIFF
--- a/src/frontend/src/components/question/QuestionForm.vue
+++ b/src/frontend/src/components/question/QuestionForm.vue
@@ -90,6 +90,10 @@ export default {
 
     async onCreateQuestion() {
       if (!this.$refs.form.validate()) {
+        await this.$store.dispatch(
+          "UPDATE_SNACKBAR_TEXT",
+          "해시태그 입력이 올바르지 않습니다."
+        );
         return;
       }
 
@@ -129,14 +133,46 @@ export default {
 
     async onUpdateQuestion() {
       if (!this.$refs.form.validate()) {
+        await this.$store.dispatch(
+          "UPDATE_SNACKBAR_TEXT",
+          "해시태그 입력이 올바르지 않습니다."
+        );
         return;
       }
 
-      await this.$store.dispatch("UPDATE_QUESTION", {
-        questionId: this.questionId,
-        ...this.payload
-      });
-      await this.$router.push(`/questions/${this.questionId}`);
+      try {
+        await this.$store.dispatch("UPDATE_QUESTION", {
+          questionId: this.questionId,
+          ...this.payload
+        });
+        await this.$router.push(`/questions/${this.questionId}`);
+      } catch (error) {
+        console.log(error);
+        switch (error.response.status) {
+          case 401: {
+            await this.$store.dispatch(
+              "UPDATE_SNACKBAR_TEXT",
+              "로그인 후 사용할 수 있습니다."
+            );
+            break;
+          }
+          case 405: {
+            await this.$store.dispatch(
+              "UPDATE_SNACKBAR_TEXT",
+              "항목을 채워주세요."
+            );
+            break;
+          }
+          default: {
+            console.log("에러입니다" + error);
+            await this.$store.dispatch(
+              "UPDATE_SNACKBAR_TEXT",
+              "요청에 실패했습니다."
+            );
+            break;
+          }
+        }
+      }
     },
 
     async fetchQuestionInfo() {

--- a/src/frontend/src/components/question/QuestionList.vue
+++ b/src/frontend/src/components/question/QuestionList.vue
@@ -94,15 +94,13 @@ export default {
       return;
     }
 
-    if (this.hashtag) {
-      await this.addQuestionByHashtag();
-      return;
-    }
-
     await this.addQuestions();
   },
 
   mounted() {
+    if (this.hashtag) {
+      this.addQuestionByHashtag();
+    }
     if (!this.isLoggedIn) {
       this.$store.commit("DELETE_QUESTION_FAVORITES");
     }

--- a/src/frontend/src/store/modules/questions.js
+++ b/src/frontend/src/store/modules/questions.js
@@ -16,8 +16,6 @@ export default {
       state.questionPage = state.questionPage + 1;
       state.questionLastPage = data["lastPage"];
       state.questions = state.questions.concat(data["questions"]);
-
-      console.log(state.questions);
     },
     SET_QUESTION(state, data) {
       state.question = data;
@@ -70,7 +68,6 @@ export default {
     async FETCH_QUESTIONS_BY_HASHTAG({ commit }, hashtag) {
       const { data } = await getAction(`/api/questions?hashtag=${hashtag}`);
       commit("SET_QUESTIONS", data);
-      console.log(data);
     },
     async FETCH_QUESTION_WITHOUT_VISITS({ commit }, questionId) {
       const { data } = await getAction(

--- a/src/frontend/src/views/question/QuestionListView.vue
+++ b/src/frontend/src/views/question/QuestionListView.vue
@@ -39,21 +39,22 @@ export default {
 
   watch: {
     async hashtag() {
+      await this.$store.commit("INIT_QUESTIONS");
       if (this.hashtag) {
         await this.addQuestionByHashtag();
       }
     },
 
     async orderBy() {
+      await this.$store.commit("INIT_QUESTIONS");
       if (this.orderBy) {
-        await this.$store.commit("INIT_QUESTIONS");
         await this.addQuestions();
       }
     },
 
     async compoundKeyword() {
+      await this.$store.commit("INIT_QUESTIONS");
       if (this.title || this.content) {
-        await this.$store.commit("INIT_QUESTIONS");
         await this.addQuestions();
       }
     }
@@ -81,7 +82,6 @@ export default {
 
     async addQuestionByHashtag() {
       try {
-        await this.$store.commit("INIT_QUESTIONS");
         await this.$store.dispatch("FETCH_QUESTIONS_BY_HASHTAG", this.hashtag);
       } catch (error) {
         console.log("해시태그로 질문 조회 실패");

--- a/src/main/java/underdogs/devbie/answer/domain/RecommendationCount.java
+++ b/src/main/java/underdogs/devbie/answer/domain/RecommendationCount.java
@@ -19,12 +19,12 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class RecommendationCount {
 
-    @Formula("select count(*) from answer_recommendation a "
-        + "where a.answer_id = answer_id and a.recommendation_type = 'RECOMMENDED'")
+    @Formula(value="(select count(*) from answer_recommendation a "
+        + "where a.answer_id = answer_id and a.recommendation_type = 'RECOMMENDED')")
     private Long recommendedCount;
 
-    @Formula("select count(*) from answer_recommendation a "
-        + "where a.answer_id = answer_id and a.recommendation_type = 'NON_RECOMMENDED'")
+    @Formula(value="(select count(*) from answer_recommendation a "
+        + "where a.answer_id = answer_id and a.recommendation_type = 'NON_RECOMMENDED')")
     private Long nonRecommendedCount;
 
     public static RecommendationCount init() {


### PR DESCRIPTION
## Resolve #226 

- Hashtag 클릭으로 질문 검색 시, 원하는 결과가 나오지 않는다.
---
- answer subquery문제
- 불필요한 console.log 잔재
- 질문 수정시 snack bar안나오는 문제

## Changes

- mounted 될때 해시태그 검색 Api를 새로 쏜다.
- console.log 제거
- answer subquery에 () 추가
- snackbar 호출코드 추가

## Notes

- N/A

## References

- N/A
