### PR TITLE
fix: 답변 수정시 마크다운 적용 안되는 문제

### DIFF
--- a/src/frontend/src/components/question/AnswerItem.vue
+++ b/src/frontend/src/components/question/AnswerItem.vue
@@ -127,7 +127,6 @@ export default {
           updateContent: this.content
         });
         this.updateEditFlag = !this.updateEditFlag;
-        this.content = this.content.split("\n").join("<br />");
       } catch (error) {
         console.error(error);
         console.error(error.response.data.message);


### PR DESCRIPTION
## Resolve #230 

- 답변 수정할 때 마크다운 형식이 깨진다.

## Changes

- 기존에 텍스트 방식으로 줄바꿈했던 코드를 삭제한다.

## Notes

- N/A

## References

- N/A
