### PR TITLE
[Fix] CI과정에서 Pull Request는 배포하지 않도록 설정

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,14 @@ cache:
 script: "./gradlew clean build"
 
 after_success:
-  - cd docker
-  - git add .
-  - git commit -m "updated in travis"
-  - git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker
-  - cd ..
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    cd docker;
+    git add .;
+    git commit -m "updated in travis";
+    git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker;
+    cd ..;
 
-  - docker build -t kimseonggyu1/devbie:latest .
-  - docker login -u $DOCKER_USER -p $PASSWORD
-  - docker push kimseonggyu1/devbie:latest
+    docker build -t kimseonggyu1/devbie:latest .;
+    docker login -u $DOCKER_USER -p $PASSWORD;
+    docker push kimseonggyu1/devbie:latest;
+  fi


### PR DESCRIPTION
## Resolve #256

- 이전에 .yml옵션에서 Push/PR을 CI를 돌리게되면 자동으로 배포되게 설정되어있다.
  - 이렇게되면 PR에서도 자동배포가되어 문제가 발생할 수 있다고 판단했다.
  - yml 옵션에서 if문을 달아서 PR은 배포하지않도록 설정한다.
- 지금은 PR을 CI를 안하도록하여, PR에서 빌드가 잘되는지 알 수가 없다.

## Changes

- PR인 경우 배포하지 않도록 설정
- Merge 후 트래비스 사이트 설정에서 PR도 CI하도록 변경하겠음.

## Notes

if문 안의 명령어 끝날 때 꼭!! 세미콜론 넣어주세요. yml파일을 불러드렸을 때 명령어의 개행을 인식못해요. 아래 링크 참고하시면 되겠습니다.

## References

- [스택오버플로](https://stackoverflow.com/questions/38789253/running-script-conditionally-does-not-work-in-travis-yml-why)
