### PR TITLE
fix: 즐겨찾기 페이지 공고 클릭 시 상세 페이지로 이동 & 반응형 디자인 적용

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -2547,6 +2547,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5236,6 +5246,13 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -6924,11 +6941,6 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.startswith": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
-      "integrity": "sha1-xZjErc4YiiflMUVzHNxsDnF3YAw="
-    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
@@ -7067,14 +7079,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
       "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
-    },
-    "marked-images": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked-images/-/marked-images-2.0.1.tgz",
-      "integrity": "sha512-UcGd5zOBF+MexwFHZEaVljD1ZbzsuljXZFO5DlEJ+tgOTUAzP66QPZtOgW78AvAhtbhzPxkasCnFMu3s/CwN1A==",
-      "requires": {
-        "lodash.startswith": "^4.2.1"
-      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -7422,6 +7426,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11260,7 +11271,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-binary-path": {
           "version": "1.0.1",
@@ -11547,7 +11562,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "is-absolute-url": {
           "version": "3.0.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -12,7 +12,6 @@
     "axios": "^0.19.2",
     "core-js": "^3.6.5",
     "marked": "^1.1.1",
-    "marked-images": "^2.0.1",
     "path": "^0.12.7",
     "reset-css": "^5.0.1",
     "router": "^1.3.5",

--- a/src/frontend/src/components/FooterBar.vue
+++ b/src/frontend/src/components/FooterBar.vue
@@ -3,26 +3,20 @@
     <v-footer dark padless color="#9FD0D4" id="footer">
       <v-card flat tile color="#9FD0D4" class="lighten-1 white--text">
         <v-card-text>
-          <v-btn
-            v-for="icon in icons"
-            :key="icon"
-            class="mx-4 white--text"
-            icon
+          <a
+            href="https://www.facebook.com/Devbie-101790985021306/?notif_id=1600704082047732&notif_t=page_fan&ref=notif"
+            ><v-icon class="sns" size="30px">{{ "mdi-facebook" }}</v-icon></a
           >
-            <v-icon size="24px">{{ icon }}</v-icon>
-          </v-btn>
-        </v-card-text>
-
-        <v-card-text class="white--text pt-0">
-          Phasellus feugiat arcu sapien, et iaculis ipsum elementum sit amet.
-          Mauris cursus commodo interdum. Praesent ut risus eget metus luctus
-          accumsan id ultrices nunc.
+          <a href="https://github.com/woowacourse-teams/2020-devbie"
+            ><v-icon class="sns" size="30px">{{ "mdi-github" }}</v-icon></a
+          >
         </v-card-text>
 
         <v-divider></v-divider>
 
         <v-card-text class="white--text">
-          {{ new Date().getFullYear() }} — <strong>Underdogs</strong>
+          Copyright © {{ new Date().getFullYear() }} —
+          <strong>Underdogs</strong>
         </v-card-text>
       </v-card>
     </v-footer>
@@ -40,6 +34,9 @@ export default {
 </script>
 
 <style scoped>
+.sns {
+  margin: 0 10px;
+}
 #footer {
   text-align: center;
   display: flex;

--- a/src/frontend/src/components/FooterBar.vue
+++ b/src/frontend/src/components/FooterBar.vue
@@ -38,6 +38,7 @@ export default {
   margin: 0 10px;
 }
 #footer {
+  min-height: 165px;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/src/frontend/src/components/favorite/FavoriteType.vue
+++ b/src/frontend/src/components/favorite/FavoriteType.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="select-box">
+  <div class="select-box" :class="$mq">
     <v-btn
       name="NOTICE_FAVORITE"
       class="select-btn"
@@ -40,6 +40,10 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.select-box.mobile {
+  margin: 40px auto 0 auto;
 }
 
 .select-btn {

--- a/src/frontend/src/components/favorite/NoticeFavorites.vue
+++ b/src/frontend/src/components/favorite/NoticeFavorites.vue
@@ -1,14 +1,17 @@
 <template>
   <div>
-    <v-row dense>
+    <v-row dense class="list-parent" :class="$mq">
       <div
         v-for="notice in fetchedNoticeFavorites"
         :key="notice.id"
         class="item"
+        :class="$mq"
       >
-        <v-card class="v-card">
+        <v-card>
           <v-img
-            @click.stop="$router.push(`/notices/${notice.id}`)"
+            @click="
+              $router.push(`/notices/${noticeType || 'JOB'}/${notice.id}`)
+            "
             :src="notice.image"
             class="white--text align-end card-image"
             gradient="to bottom, rgba(0,0,0,.1), rgba(0,0,0,.5)"
@@ -16,7 +19,7 @@
           >
             <v-card-title
               class="card-title-text"
-              v-text="`${notice.name} - ${notice.title}`"
+              v-html="addHighlight(sliceText(notice.name, 20))"
             ></v-card-title>
           </v-img>
 
@@ -27,7 +30,7 @@
                 class="big-font notice-title"
                 style="font-weight: bold"
               >
-                {{ notice.languages.join(", ") }}
+                <p v-html="addHighlight(sliceText(notice.title, 40))"></p>
               </div>
               <div class="medium-font">
                 언어 : {{ notice.languages.join(", ") }}
@@ -53,6 +56,8 @@ import FavoriteControl from "./FavoriteControl";
 
 export default {
   components: { FavoriteControl },
+
+  props: ["noticeType"],
 
   computed: {
     ...mapGetters([
@@ -82,32 +87,58 @@ export default {
         userId: this.fetchedLoginUser.id,
         object: "notice"
       });
+    },
+
+    sliceText(text, maximumLength) {
+      if (text.length > maximumLength) {
+        return text.substr(0, maximumLength) + "...";
+      }
+      return text;
+    },
+
+    addHighlight(text) {
+      if (this.keyword === undefined || this.keyword === "") {
+        return text;
+      }
+
+      const regex = new RegExp(this.keyword, "g");
+      const highlightingText = text.replace(
+        regex,
+        `<span style="background: #f1c40f">` + this.keyword + "</span>"
+      );
+
+      return highlightingText;
     }
   }
 };
 </script>
 
 <style scoped>
+.v-card {
+  height: 100%;
+}
+
 .big-font {
   font-size: 17px;
 }
+
 .medium-font {
   font-size: 13px;
 }
+
 .item {
   width: 22%;
   margin: 0 30px 50px 0;
-}
-.item:last-child {
-  margin-right: auto;
 }
 
 .card-image {
   width: 100%;
 }
+
 .card-image:hover {
   opacity: 0.6;
 }
+
 .card-title-text {
   justify-content: center;
   color: white;
@@ -125,5 +156,24 @@ export default {
   position: absolute;
   right: 15px;
   bottom: 15px;
+}
+
+.list-parent {
+  justify-content: center;
+  margin: 0;
+  padding-left: 2%;
+}
+
+.list-parent.mobile {
+  width: 80%;
+  margin: auto;
+}
+
+.item.mobile {
+  min-width: 100%;
+}
+
+.notice-info {
+  width: 100%;
 }
 </style>

--- a/src/frontend/src/components/favorite/QuestionFavorites.vue
+++ b/src/frontend/src/components/favorite/QuestionFavorites.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <ul class="question-list">
+    <ul class="question-list" :class="$mq">
       <li
         v-for="question in fetchedQuestionFavorites"
         v-bind:key="question.id"

--- a/src/frontend/src/components/question/AnswerCreate.vue
+++ b/src/frontend/src/components/question/AnswerCreate.vue
@@ -18,7 +18,10 @@ export default {
   methods: {
     createAnswer: async function() {
       if (this.content.trim() === "") {
-        this.$store.dispatch("UPDATE_SNACKBAR_TEXT", "답변을 채워주세요.");
+        await this.$store.dispatch(
+          "UPDATE_SNACKBAR_TEXT",
+          "답변을 채워주세요."
+        );
         return;
       }
       try {
@@ -29,14 +32,17 @@ export default {
       } catch (error) {
         console.log(error);
         if (error.response.status === 401) {
-          this.$store.dispatch(
+          await this.$store.dispatch(
             "UPDATE_SNACKBAR_TEXT",
             "로그인 후 사용할 수 있습니다."
           );
         } else if (error.response.status === 405) {
-          this.$store.dispatch("UPDATE_SNACKBAR_TEXT", "답변을 채워주세요.");
+          await this.$store.dispatch(
+            "UPDATE_SNACKBAR_TEXT",
+            "답변을 채워주세요."
+          );
         } else {
-          this.$store.dispatch(
+          await this.$store.dispatch(
             "UPDATE_SNACKBAR_TEXT",
             "요청 실패했습니다. 원인 : " + error.response.data.message
           );

--- a/src/frontend/src/components/question/AnswerItem.vue
+++ b/src/frontend/src/components/question/AnswerItem.vue
@@ -265,7 +265,7 @@ export default {
 }
 
 .answer-temp {
-  min-width: 100%;
+  max-width: 100%;
   padding: 20px 30px;
 }
 

--- a/src/frontend/src/components/question/MarkdownContent.vue
+++ b/src/frontend/src/components/question/MarkdownContent.vue
@@ -1,12 +1,11 @@
 <template>
   <div>
-    <div v-html="changeToMarkdown"></div>
+    <div class="paragraph" v-html="changeToMarkdown"></div>
   </div>
 </template>
 
 <script>
 import marked from "marked";
-import markedImages from "marked-images";
 
 export default {
   props: ["content"],
@@ -15,18 +14,17 @@ export default {
     changeToMarkdown() {
       return marked(this.content);
     }
-  },
-
-  created() {
-    const opts = {
-      xhtml: false,
-      fqImages: { route: "/images/", url: "https://images.example.com" },
-      fqLinks: "https://www.example.com",
-      relPath: false
-    };
-    marked.use(markedImages(opts));
   }
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.paragraph {
+  word-wrap: break-word;
+}
+
+.paragraph /deep/ img {
+  max-width: 100% !important;
+  height: auto !important;
+}
+</style>

--- a/src/frontend/src/views/favorite/NoticeFavoriteView.vue
+++ b/src/frontend/src/views/favorite/NoticeFavoriteView.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="notice-fovorite-list" style="margin: 50px 150px 50px 150px">
+  <div
+    class="notice-fovorite-list"
+    :class="$mq"
+    style="margin: 50px 150px 50px 150px"
+  >
     <div class="filters">
       <favorite-type :isNoticeFavorite="true"></favorite-type>
     </div>
@@ -29,5 +33,9 @@ export default {
 
 .filters > * {
   margin-right: 120px;
+}
+
+.notice-fovorite-list.mobile {
+  margin: 0 !important;
 }
 </style>

--- a/src/frontend/src/views/favorite/NoticeFavoriteView.vue
+++ b/src/frontend/src/views/favorite/NoticeFavoriteView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="notice-fovorite-list"
+    class="notice-favorite-list"
     :class="$mq"
     style="margin: 50px 150px 50px 150px"
   >
@@ -35,7 +35,7 @@ export default {
   margin-right: 120px;
 }
 
-.notice-fovorite-list.mobile {
+.notice-favorite-list.mobile {
   margin: 0 !important;
 }
 </style>

--- a/src/frontend/src/views/favorite/QuestionFavoriteView.vue
+++ b/src/frontend/src/views/favorite/QuestionFavoriteView.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="notice-fovorite-list" style="margin: 50px 150px 50px 150px">
+  <div
+    class="notice-favorite-list"
+    :class="$mq"
+    style="margin: 50px 150px 50px 150px"
+  >
     <div class="filters">
       <favorite-type :isQuestionFavorite="true"></favorite-type>
     </div>
@@ -46,6 +50,10 @@ export default {
 
 .filters > * {
   margin-right: 120px;
+}
+
+.notice-favorite-list.mobile {
+  margin: 0 !important;
 }
 
 #question-list {


### PR DESCRIPTION
## Resolve #288 

- 즐겨찾기 페이지에서 공고 클릭 시 상세 페이지로 이동하지 않는다
- 화면을 줄이면 항목 UI가 깨진다.

## Changes

- 공고리스트에서 적용된 로직을 즐겨찾기에도 적용 (항목 클릭시 url을 통해 파라미터 전달)
- 반응형 디자인 적용

## Notes

- 보스독이 반응형 디자인 적용

## References

- N/A
