### PR TITLE
[Bugfix] 공고 수정이 안되는 이슈해결

### DIFF
--- a/src/frontend/src/components/notice/NoticeDetail.vue
+++ b/src/frontend/src/components/notice/NoticeDetail.vue
@@ -88,7 +88,10 @@
               <i class="fas fa-keyboard"></i>
               포지션: {{ notice.jobPosition }}
             </p>
-            <p class="infos"><i class="fas fa-burn"></i>언어:</p>
+            <p class="infos">
+              <i class="fas fa-burn"></i>언어:
+              {{ notice.noticeDescription.languages.join(", ") }}
+            </p>
             <p class="infos">
               <template v-for="(line, index) in content">
                 {{ line }}

--- a/src/frontend/src/utils/noticeUtil.js
+++ b/src/frontend/src/utils/noticeUtil.js
@@ -1,7 +1,14 @@
 const dict = {
   "C++": "CPP",
-  JAVA: "JAVA",
-  C: "C"
+  Java: "JAVA",
+  C: "C",
+  "C#": "C_SHARP",
+  JAVASCRIPT: "JAVASCRIPT",
+  TYPESCRIPT: "TYPESCRIPT",
+  PYTHON: "PYTHON",
+  RUBY: "RUBY",
+  PHP: "PHP",
+  SWIFT: "SWIFT"
 };
 
 export const languageTranslator = language => {


### PR DESCRIPTION
## Resolve #292 

- 공고 수정이 안된다..

## Changes

- ENUM에 매칭되는 프로그래밍 언어를 프론트엔드에서 모른다.
- 프론트엔드에서 공고타입을 추가한다.

## Notes

- 지금 상황이 되게 비효율적이라고 생각합니다. 현재 프론트엔드-서버간에 ENUM KEY 값으로 데이터를 주고받는데, 이렇게하니 프론트엔드에서도 서버가 변경될때마다 프론트도 변경되어야하는 불편함이 있습니다. 다음 주 리팩토링에 ENUM의 name으로 데이터를 주고받도록 변경하겠습니다.

