### PR TITLE
feat : 참조되지 않는 해시태그 제거

### DIFF
--- a/src/main/java/underdogs/devbie/config/AsyncConfig.java
+++ b/src/main/java/underdogs/devbie/config/AsyncConfig.java
@@ -1,9 +1,24 @@
 package underdogs.devbie.config;
 
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(3);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setQueueCapacity(10);
+        taskExecutor.setThreadNamePrefix("Executor-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
 }

--- a/src/main/java/underdogs/devbie/config/AsyncConfig.java
+++ b/src/main/java/underdogs/devbie/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package underdogs.devbie.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}

--- a/src/main/java/underdogs/devbie/question/domain/Hashtag.java
+++ b/src/main/java/underdogs/devbie/question/domain/Hashtag.java
@@ -1,12 +1,17 @@
 package underdogs.devbie.question.domain;
 
+import static javax.persistence.CascadeType.*;
+
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,6 +33,9 @@ public class Hashtag extends BaseTimeEntity {
 
     @Embedded
     private TagName tagName;
+
+    @OneToMany(mappedBy = "hashtag", cascade = ALL)
+    private Set<QuestionHashtag> questionHashtags = new LinkedHashSet<>();
 
     @Builder
     public Hashtag(Long id, TagName tagName) {

--- a/src/main/java/underdogs/devbie/question/domain/QuestionHashtags.java
+++ b/src/main/java/underdogs/devbie/question/domain/QuestionHashtags.java
@@ -1,5 +1,6 @@
 package underdogs.devbie.question.domain;
 
+import static javax.persistence.CascadeType.*;
 import static javax.persistence.FetchType.*;
 
 import java.util.LinkedHashSet;
@@ -23,7 +24,7 @@ import lombok.ToString;
 @ToString
 public class QuestionHashtags {
 
-    @OneToMany(fetch = LAZY, orphanRemoval = true, mappedBy = "question")
+    @OneToMany(fetch = LAZY, cascade = ALL, orphanRemoval = true, mappedBy = "question")
     private Set<QuestionHashtag> questionHashtags = new LinkedHashSet<>();
 
     public static QuestionHashtags from(Set<QuestionHashtag> questionHashtags) {

--- a/src/main/java/underdogs/devbie/question/domain/QuestionHashtags.java
+++ b/src/main/java/underdogs/devbie/question/domain/QuestionHashtags.java
@@ -46,4 +46,10 @@ public class QuestionHashtags {
         this.questionHashtags.clear();
         this.questionHashtags.addAll(questionHashtags);
     }
+
+    public List<Hashtag> toPureHashtags() {
+        return this.questionHashtags.stream()
+            .map(QuestionHashtag::getHashtag)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepository.java
+++ b/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import underdogs.devbie.question.domain.Hashtag;
 import underdogs.devbie.question.domain.TagName;
 
-public interface HashtagRepository extends JpaRepository<Hashtag, Long>  {
+public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagRepositoryCustom {
 
     Optional<Hashtag> findByTagName(TagName tagName);
 }

--- a/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepositoryCustom.java
+++ b/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepositoryCustom.java
@@ -1,0 +1,10 @@
+package underdogs.devbie.question.domain.repository;
+
+import java.util.List;
+
+import underdogs.devbie.question.domain.Hashtag;
+
+public interface HashtagRepositoryCustom {
+
+    void deleteEmptyRefHashtag(List<Hashtag> hashtags);
+}

--- a/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepositoryImpl.java
+++ b/src/main/java/underdogs/devbie/question/domain/repository/HashtagRepositoryImpl.java
@@ -1,0 +1,38 @@
+package underdogs.devbie.question.domain.repository;
+
+import static underdogs.devbie.question.domain.QHashtag.*;
+import static underdogs.devbie.question.domain.QQuestionHashtag.*;
+
+import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import underdogs.devbie.question.domain.Hashtag;
+
+public class HashtagRepositoryImpl implements HashtagRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public HashtagRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public void deleteEmptyRefHashtag(List<Hashtag> hashtags) {
+        hashtags.forEach(h ->
+            jpaQueryFactory
+            .delete(hashtag)
+            .where(neverReferenced(h), hashtag.id.eq(h.getId()))
+            .execute()
+        );
+    }
+
+    private BooleanExpression neverReferenced(Hashtag hashtag) {
+        long refCount = jpaQueryFactory
+            .selectFrom(questionHashtag)
+            .where(questionHashtag.hashtag.id.eq(hashtag.getId()))
+            .fetchCount();
+        return Expressions.asBoolean(refCount == 0).isTrue();
+    }
+}

--- a/src/main/java/underdogs/devbie/question/service/HashtagService.java
+++ b/src/main/java/underdogs/devbie/question/service/HashtagService.java
@@ -10,8 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import underdogs.devbie.question.domain.Hashtag;
-import underdogs.devbie.question.domain.repository.HashtagRepository;
+import underdogs.devbie.question.domain.QuestionHashtags;
 import underdogs.devbie.question.domain.TagName;
+import underdogs.devbie.question.domain.repository.HashtagRepository;
 import underdogs.devbie.question.dto.HashtagCreateRequest;
 import underdogs.devbie.question.dto.HashtagResponse;
 import underdogs.devbie.question.dto.HashtagResponses;
@@ -77,5 +78,10 @@ public class HashtagService {
                 .tagName(TagName.from(tagName))
                 .build());
         return hashtagRepository.save(hashtag);
+    }
+
+    public void deleteEmptyRefHashtag(QuestionHashtags questionHashtags) {
+        List<Hashtag> hashtags = questionHashtags.toPureHashtags();
+        hashtagRepository.deleteEmptyRefHashtag(hashtags);
     }
 }

--- a/src/main/java/underdogs/devbie/question/service/QuestionHashtagService.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionHashtagService.java
@@ -49,12 +49,11 @@ public class QuestionHashtagService {
     }
 
     private QuestionHashtag findOrCreateQuestionHashtag(Question question, Hashtag hashtag) {
-        QuestionHashtag questionHashtag = questionHashtagRepository.findByQuestionIdAndHashtagId(question.getId(), hashtag.getId())
+        return questionHashtagRepository.findByQuestionIdAndHashtagId(question.getId(), hashtag.getId())
             .orElse(QuestionHashtag.builder()
                 .question(question)
                 .hashtag(hashtag)
                 .build());
-        return questionHashtagRepository.save(questionHashtag);
     }
 
     public List<Long> findIdsByHashtagName(String hashtag) {

--- a/src/main/java/underdogs/devbie/question/service/QuestionService.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package underdogs.devbie.question.service;
 
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import underdogs.devbie.question.dto.QuestionResponses;
 import underdogs.devbie.question.dto.QuestionUpdateRequest;
 import underdogs.devbie.question.exception.NotMatchedQuestionAuthorException;
 import underdogs.devbie.question.exception.QuestionNotExistedException;
+import underdogs.devbie.question.service.event.QuestionDeleteEvent;
 import underdogs.devbie.recommendation.domain.RecommendationType;
 import underdogs.devbie.user.domain.User;
 import underdogs.devbie.user.service.UserService;
@@ -29,6 +31,7 @@ public class QuestionService {
     private final UserService userService;
     private final QuestionHashtagService questionHashtagService;
     private final QuestionRepository questionRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Long save(Long userId, QuestionCreateRequest request) {
@@ -87,6 +90,8 @@ public class QuestionService {
         validateQuestionAuthorOrAdmin(user, question);
 
         questionRepository.deleteById(questionId);
+
+        eventPublisher.publishEvent(new QuestionDeleteEvent(this, question.getHashtags()));
     }
 
     private void validateQuestionAuthorOrAdmin(User user, Question question) {

--- a/src/main/java/underdogs/devbie/question/service/event/QuestionDeleteEvent.java
+++ b/src/main/java/underdogs/devbie/question/service/event/QuestionDeleteEvent.java
@@ -1,0 +1,17 @@
+package underdogs.devbie.question.service.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import lombok.Getter;
+import underdogs.devbie.question.domain.QuestionHashtags;
+
+@Getter
+public class QuestionDeleteEvent extends ApplicationEvent {
+
+    private final QuestionHashtags questionHashtags;
+
+    public QuestionDeleteEvent(Object source, QuestionHashtags questionHashtags) {
+        super(source);
+        this.questionHashtags = questionHashtags;
+    }
+}

--- a/src/main/java/underdogs/devbie/question/service/event/QuestionDeleteListener.java
+++ b/src/main/java/underdogs/devbie/question/service/event/QuestionDeleteListener.java
@@ -1,0 +1,23 @@
+package underdogs.devbie.question.service.event;
+
+import static org.springframework.transaction.event.TransactionPhase.*;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import underdogs.devbie.question.service.HashtagService;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionDeleteListener {
+
+    private final HashtagService hashtagService;
+
+    @Async("threadPoolTaskExecutor")
+    @TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)
+    public void handleQuestionDelete(QuestionDeleteEvent event) {
+        hashtagService.deleteEmptyRefHashtag(event.getQuestionHashtags());
+    }
+}

--- a/src/test/java/underdogs/devbie/question/domain/repository/HashtagRepositoryImplTest.java
+++ b/src/test/java/underdogs/devbie/question/domain/repository/HashtagRepositoryImplTest.java
@@ -1,0 +1,45 @@
+package underdogs.devbie.question.domain.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import underdogs.devbie.question.domain.Hashtag;
+import underdogs.devbie.question.domain.TagName;
+
+@SpringBootTest
+@Transactional
+class HashtagRepositoryImplTest {
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    @BeforeEach
+    public void setUp() {
+        Hashtag hashtag1 = Hashtag.builder().id(10L).tagName(TagName.from("java")).build();
+        Hashtag hashtag2 = Hashtag.builder().id(11L).tagName(TagName.from("network")).build();
+
+        hashtagRepository.save(hashtag1);
+        hashtagRepository.save(hashtag2);
+    }
+
+    @DisplayName("참조하고 있는 질문이 없을 경우 해시태그 자동 삭제")
+    @Test
+    public void deleteEmptyRefHashtags() {
+        List<Hashtag> hashtags = hashtagRepository.findAll();
+
+        hashtagRepository.deleteEmptyRefHashtag(hashtags);
+
+        List<Hashtag> afterDeletedHashtags = hashtagRepository.findAll();
+
+        assertThat(afterDeletedHashtags).isEmpty();
+    }
+
+}

--- a/src/test/java/underdogs/devbie/question/service/QuestionHashtagServiceTest.java
+++ b/src/test/java/underdogs/devbie/question/service/QuestionHashtagServiceTest.java
@@ -8,6 +8,7 @@ import static underdogs.devbie.question.domain.QuestionTest.*;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,9 +22,9 @@ import com.google.common.collect.Lists;
 import underdogs.devbie.question.domain.Hashtag;
 import underdogs.devbie.question.domain.Question;
 import underdogs.devbie.question.domain.QuestionHashtag;
-import underdogs.devbie.question.domain.repository.QuestionHashtagRepository;
 import underdogs.devbie.question.domain.QuestionHashtags;
 import underdogs.devbie.question.domain.TagName;
+import underdogs.devbie.question.domain.repository.QuestionHashtagRepository;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionHashtagServiceTest {
@@ -61,13 +62,6 @@ class QuestionHashtagServiceTest {
     @Test
     void saveHashtags() {
         given(hashtagService.findOrCreateHashtag(anyString())).willReturn(hashtag);
-        given(questionHashtagRepository.save(any(QuestionHashtag.class))).willReturn(
-            QuestionHashtag.builder()
-                .id(1L)
-                .question(question)
-                .hashtag(hashtag)
-                .build()
-        );
 
         questionHashtagService.saveHashtags(question, Sets.newSet("java"));
 
@@ -86,14 +80,12 @@ class QuestionHashtagServiceTest {
             .id(3L)
             .tagName(TagName.from("kotlin"))
             .build();
+        QuestionHashtag questionHashtag = QuestionHashtag.builder()
+            .question(question)
+            .hashtag(updateHashtag)
+            .build();
         given(hashtagService.findOrCreateHashtag(anyString())).willReturn(hashtag);
-        given(questionHashtagRepository.save(any(QuestionHashtag.class))).willReturn(
-            QuestionHashtag.builder()
-                .id(1L)
-                .question(question)
-                .hashtag(updateHashtag)
-                .build()
-        );
+        given(questionHashtagRepository.findByQuestionIdAndHashtagId(any(), any())).willReturn(Optional.of(questionHashtag));
 
         questionHashtagService.updateHashtags(question, Sets.newSet("kotlin"));
 

--- a/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
+++ b/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,9 +30,9 @@ import underdogs.devbie.question.domain.Question;
 import underdogs.devbie.question.domain.QuestionContent;
 import underdogs.devbie.question.domain.QuestionHashtag;
 import underdogs.devbie.question.domain.QuestionHashtags;
-import underdogs.devbie.question.domain.repository.QuestionRepository;
 import underdogs.devbie.question.domain.QuestionTitle;
 import underdogs.devbie.question.domain.TagName;
+import underdogs.devbie.question.domain.repository.QuestionRepository;
 import underdogs.devbie.question.dto.HashtagResponse;
 import underdogs.devbie.question.dto.QuestionCreateRequest;
 import underdogs.devbie.question.dto.QuestionPageRequest;
@@ -61,6 +62,9 @@ public class QuestionServiceTest {
     @Mock
     private QuestionRepository questionRepository;
 
+    @Mock
+    private ApplicationEventPublisher publisher;
+
     private User user;
 
     private Question question;
@@ -69,7 +73,7 @@ public class QuestionServiceTest {
 
     @BeforeEach
     void setUp() {
-        questionService = new QuestionService(userService, questionHashtagService, questionRepository);
+        questionService = new QuestionService(userService, questionHashtagService, questionRepository, publisher);
 
         user = User.builder()
             .id(1L)


### PR DESCRIPTION
## Resolve #311 

- Question이 지워질때 다른 Question에서도 참조되지 않는 해시태그가 있다면 함께 지운다.

## Changes
- Question을 지우는 이벤트를 만들고, 이벤트 리스너에서 HashtagService의 deleteEmptyRefHashtags메서드를 실행시켜 검사후 지운다.

## Notes
- 하나의 트랜잭션으로 묶지 않은 이유는 질문을 지우는 것과 관련없는 일이기 때문에 다른 스레드에서 수행되게한다.
- 또한 이벤트를 발행하면 HashtagService를 직접적으로 의존할 필요없어진다. 


## References

