### PR TITLE
[REFACTOR] profile을 환경변수로 분기하도록 설정 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=develop
+spring.profiles.active=${DEVBIE_ENV:local}


### PR DESCRIPTION
## Resolve #297

- 로컬/개발서버에서 배포할때마다 application.properties를 바꾸면서 작업해야한다.

## Changes

- 트래비스 CI 페이지에 branch별 환경변수 추가
![image](https://user-images.githubusercontent.com/33685054/94799915-d55b6a00-041e-11eb-8557-4121f5379dc9.png)
- 로컬에서는 환경변수를 등록안해놨기 때문에, 디폴트 값으로 local을 갖도록 변경(개발 편의를 위함)

확인하지 못한 것
 - 도커 빌드할때 환경변수 필요한지
 - docker-compose할 때 환경변수 필요한지

## Notes

- Travis에서 브랜치별 환경변수를 넣을 수 있는게 편하네요.
- 빨리 젠킨스로 갈아타고싶은 생각

## References

- N/A
