### PR TITLE
refactor : 테이블 인덱스 추가

### DIFF
--- a/src/main/java/underdogs/devbie/answer/domain/Answer.java
+++ b/src/main/java/underdogs/devbie/answer/domain/Answer.java
@@ -21,7 +21,7 @@ import underdogs.devbie.recommendation.domain.RecommendationCount;
 import underdogs.devbie.recommendation.domain.RecommendationType;
 
 @Entity
-@Table(indexes = @Index(name = "i_answer", columnList = "question_id"))
+@Table(indexes = @Index(name = "i_answer", columnList = "questionId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/answer/domain/Answer.java
+++ b/src/main/java/underdogs/devbie/answer/domain/Answer.java
@@ -7,6 +7,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,6 +21,7 @@ import underdogs.devbie.recommendation.domain.RecommendationCount;
 import underdogs.devbie.recommendation.domain.RecommendationType;
 
 @Entity
+@Table(indexes = @Index(name = "i_answer", columnList = "question_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/chat/domain/ChatRoom.java
+++ b/src/main/java/underdogs/devbie/chat/domain/ChatRoom.java
@@ -7,7 +7,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(indexes = @Index(name = "i_chat_room", columnList = "notice_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/underdogs/devbie/chat/domain/ChatRoom.java
+++ b/src/main/java/underdogs/devbie/chat/domain/ChatRoom.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(indexes = @Index(name = "i_chat_room", columnList = "notice_id"))
+@Table(indexes = @Index(name = "i_chat_room", columnList = "noticeId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/underdogs/devbie/favorite/domain/NoticeFavorite.java
+++ b/src/main/java/underdogs/devbie/favorite/domain/NoticeFavorite.java
@@ -3,6 +3,8 @@ package underdogs.devbie.favorite.domain;
 import java.util.Objects;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_notice_favorite", columnList = "user_id, notice_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/favorite/domain/NoticeFavorite.java
+++ b/src/main/java/underdogs/devbie/favorite/domain/NoticeFavorite.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_notice_favorite", columnList = "user_id, notice_id"))
+@Table(indexes = @Index(name = "i_notice_favorite", columnList = "userId, noticeId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/favorite/domain/QuestionFavorite.java
+++ b/src/main/java/underdogs/devbie/favorite/domain/QuestionFavorite.java
@@ -3,6 +3,8 @@ package underdogs.devbie.favorite.domain;
 import java.util.Objects;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_question_favorite", columnList = "user_id, question_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/favorite/domain/QuestionFavorite.java
+++ b/src/main/java/underdogs/devbie/favorite/domain/QuestionFavorite.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_question_favorite", columnList = "user_id, question_id"))
+@Table(indexes = @Index(name = "i_question_favorite", columnList = "userId, questionId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -10,6 +10,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,6 +22,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_notice", columnList = "notice_type, job_position, languages"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -22,7 +22,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_notice", columnList = "jobPosition, noticeType"))
+@Table(indexes = @Index(name = "i_notice", columnList = "noticeType, jobPosition"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -22,7 +22,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_notice", columnList = "job_position, languages, notice_type"))
+@Table(indexes = @Index(name = "i_notice", columnList = "jobPosition, noticeType"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/notice/domain/Notice.java
+++ b/src/main/java/underdogs/devbie/notice/domain/Notice.java
@@ -22,7 +22,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_notice", columnList = "notice_type, job_position, languages"))
+@Table(indexes = @Index(name = "i_notice", columnList = "job_position, languages, notice_type"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/question/domain/Hashtag.java
+++ b/src/main/java/underdogs/devbie/question/domain/Hashtag.java
@@ -19,7 +19,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_hashtag", columnList = "tag_name"))
+@Table(indexes = @Index(name = "i_hashtag", columnList = "name"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/question/domain/Hashtag.java
+++ b/src/main/java/underdogs/devbie/question/domain/Hashtag.java
@@ -7,6 +7,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,6 +19,7 @@ import underdogs.devbie.config.BaseTimeEntity;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_hashtag", columnList = "tag_name"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/question/domain/QuestionHashtag.java
+++ b/src/main/java/underdogs/devbie/question/domain/QuestionHashtag.java
@@ -6,6 +6,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -17,7 +18,8 @@ import lombok.NoArgsConstructor;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(name = "question_hashtag")
+@Table(name = "question_hashtag",
+    indexes = @Index(name = "i_question_hashtag", columnList = "hashtag_id, question_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class QuestionHashtag {

--- a/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
+++ b/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
@@ -3,6 +3,8 @@ package underdogs.devbie.recommendation.domain;
 import java.util.Objects;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_notice_recommendation", columnList = "user_id, notice_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
+++ b/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_notice_recommendation", columnList = "user_id, notice_id"))
+@Table(indexes = @Index(name = "i_answer_recommendation", columnList = "user_id, answer_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
+++ b/src/main/java/underdogs/devbie/recommendation/domain/AnswerRecommendation.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_answer_recommendation", columnList = "user_id, answer_id"))
+@Table(indexes = @Index(name = "i_answer_recommendation", columnList = "userId, answerId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/recommendation/domain/QuestionRecommendation.java
+++ b/src/main/java/underdogs/devbie/recommendation/domain/QuestionRecommendation.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
-@Table(indexes = @Index(name = "i_question_recommendation", columnList = "user_id, question_id"))
+@Table(indexes = @Index(name = "i_question_recommendation", columnList = "userId, questionId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/recommendation/domain/QuestionRecommendation.java
+++ b/src/main/java/underdogs/devbie/recommendation/domain/QuestionRecommendation.java
@@ -3,6 +3,8 @@ package underdogs.devbie.recommendation.domain;
 import java.util.Objects;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import lombok.ToString;
 import underdogs.devbie.exception.CreateFailException;
 
 @Entity
+@Table(indexes = @Index(name = "i_question_recommendation", columnList = "user_id, question_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/underdogs/devbie/user/domain/User.java
+++ b/src/main/java/underdogs/devbie/user/domain/User.java
@@ -6,6 +6,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,6 +19,7 @@ import underdogs.devbie.auth.dto.UserInfoDto;
 import underdogs.devbie.config.BaseTimeEntity;
 
 @Entity
+@Table(indexes = @Index(name = "i_user", columnList = "oauth_id"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter

--- a/src/main/java/underdogs/devbie/user/domain/User.java
+++ b/src/main/java/underdogs/devbie/user/domain/User.java
@@ -19,7 +19,7 @@ import underdogs.devbie.auth.dto.UserInfoDto;
 import underdogs.devbie.config.BaseTimeEntity;
 
 @Entity
-@Table(indexes = @Index(name = "i_user", columnList = "oauth_id"))
+@Table(indexes = @Index(name = "i_user", columnList = "oauthId"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter


### PR DESCRIPTION
## Resolve #316

- 조건문으로 검색 시 효율을 높이기 위해 인덱스를 추가한다.

## Changes
각 엔티티에서 오른쪽 명시된 컬럼을 기준으로 인덱스 생성
- ChatRoom → noticeId
- Notice → jobPosition, noticeType
- NoticeFavorite → userId, noticeId
- Hashtag → name
- QuestionHashtag → question_id, hashtag_id
- QuestionFavorite → userId, questionId
- QuestionRecommendation → userId, questionId
- AnswerRecommendation → userId, answerId
- Answer → questionId
- User → oauthId

## Notes

- 현재는 @Table(indexes = ~)로 추가된 거라서 머지되더라도 서버에 반영되진 않습니다. 빠뜨린 부분이나, 실수한 부분이 있다면 수정 후 머지하고, 실제 서버 스키마에서 직접적으로 인덱스 테이블 추가해줘야합니다.

## References

- N/A
