### PR TITLE
feat : 질문 검색을 위한 엘라스틱 서치 클라이언트 부분

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
+    compile group: 'org.springframework.data', name: 'spring-data-elasticsearch', version: '4.0.4.RELEASE'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/frontend/src/components/question/SearchBar.vue
+++ b/src/frontend/src/components/question/SearchBar.vue
@@ -1,17 +1,5 @@
 <template>
   <div class="search-bar" :class="$mq">
-    <v-select
-      class="filters"
-      :class="$mq"
-      v-model="selectedScope"
-      item-text="name"
-      item-value="value"
-      :items="scopes"
-      hide-details
-      menu-props="auto"
-      return-object
-      single-line
-    ></v-select>
     <v-text-field
       v-model="keyword"
       label="질문 검색"
@@ -29,61 +17,17 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
-
 export default {
   data() {
     return {
-      scopes: [
-        { name: "제목", value: "TITLE" },
-        { name: "내용", value: "CONTENT" },
-        { name: "제목 + 내용", value: "BOTH" }
-      ],
-      selectedScope: {
-        name: "제목",
-        value: "TITLE"
-      },
       keyword: ""
     };
-  },
-
-  computed: {
-    ...mapGetters(["fetchedSearchScope", "fetchedQuestionKeyword"]),
-
-    title() {
-      if (this.selectedScope.value !== "CONTENT") {
-        return this.keyword;
-      }
-      return "";
-    },
-
-    content() {
-      if (this.selectedScope.value !== "TITLE") {
-        return this.keyword;
-      }
-      return "";
-    }
-  },
-
-  created() {
-    this.keyword = this.fetchedQuestionKeyword;
-    this.selectedScope =
-      this.fetchedSearchScope.length === 0
-        ? {
-            name: "제목",
-            value: "TITLE"
-          }
-        : this.fetchedSearchScope && this.fetchedSearchScope[0];
   },
 
   methods: {
     searchByInput(event) {
       event.preventDefault();
-      this.$router.push(
-        `/questions?title=${this.title}&content=${this.content}`
-      );
-      this.$store.commit("SET_SEARCH_SCOPE", this.selectedScope);
-      this.$store.commit("SET_KEYWORD", this.keyword);
+      this.$router.push(`/questions?q=${this.keyword}`);
     }
   }
 };
@@ -104,20 +48,6 @@ export default {
 
 .search-bar.mobile {
   max-width: 92%;
-}
-
-.filters {
-  max-width: 16%;
-  margin-right: 15px;
-}
-
-.filters.tablet {
-  min-width: 30%;
-}
-
-.filters.mobile {
-  max-width: 29%;
-  font-size: 12px;
 }
 
 .input-keyword.mobile {

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -57,8 +57,7 @@ export const router = new VueRouter({
       props: route => ({
         hashtag: route.query.hashtag,
         orderBy: route.query.orderBy,
-        title: route.query.title,
-        content: route.query.content
+        keyword: route.query.q
       })
     },
     {

--- a/src/frontend/src/store/modules/questions.js
+++ b/src/frontend/src/store/modules/questions.js
@@ -5,10 +5,8 @@ export default {
     questions: [],
     question: [],
     questionId: [],
-    searchScope: [],
     questionPage: 1,
     questionLastPage: 1000,
-    questionKeyword: "",
     questionByHashtag: []
   },
   mutations: {
@@ -26,12 +24,6 @@ export default {
     CLEAR_HASHTAGS(state) {
       state.question.hashtags = [];
     },
-    SET_SEARCH_SCOPE(state, data) {
-      state.searchScope = [data];
-    },
-    SET_KEYWORD(state, data) {
-      state.questionKeyword = data;
-    },
     INIT_QUESTIONS(state) {
       state.questions = [];
       state.questionPage = 1;
@@ -40,6 +32,10 @@ export default {
     DELETE_QUESTION(state, data) {
       const idx = state.questions.findIndex(q => q.id === data);
       state.questions.splice(idx, 1);
+    },
+    SET_SEARCHED_QUESTIONS(state, data) {
+      state.questions = [];
+      state.questions = data["questions"];
     }
   },
   actions: {
@@ -80,6 +76,10 @@ export default {
         `/api/questions/${questionId}?visit=false`
       );
       commit("SET_QUESTION", data);
+    },
+    async SEARCH_QUESTIONS({ commit }, keyword) {
+      const { data } = await getAction(`/api/questions/search?q=${keyword}`);
+      commit("SET_SEARCHED_QUESTIONS", data);
     }
   },
   getters: {

--- a/src/frontend/src/views/question/QuestionListView.vue
+++ b/src/frontend/src/views/question/QuestionListView.vue
@@ -12,9 +12,8 @@
     </div>
     <question-list
       :orderBy="orderBy"
-      :title="title"
-      :content="content"
       :hashtag="hashtag"
+      :keyword="keyword"
       class="question-list"
       :class="$mq"
     ></question-list>
@@ -33,7 +32,7 @@ export default {
     QuestionList
   },
 
-  props: ["orderBy", "title", "content", "hashtag"]
+  props: ["orderBy", "hashtag", "keyword"]
 };
 </script>
 

--- a/src/main/java/underdogs/devbie/config/AsyncConfig.java
+++ b/src/main/java/underdogs/devbie/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package underdogs.devbie.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "threadPoolTaskExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(3);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setQueueCapacity(10);
+        taskExecutor.setThreadNamePrefix("Executor-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+}

--- a/src/main/java/underdogs/devbie/config/ElasticSearchConfig.java
+++ b/src/main/java/underdogs/devbie/config/ElasticSearchConfig.java
@@ -1,0 +1,21 @@
+package underdogs.devbie.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "underdogs.devbie.question.domain.repository")
+@ComponentScan(basePackages = {"underdogs.devbie.question.service"})
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        return RestClients.create(ClientConfiguration.localhost()).rest();
+    }
+}
+

--- a/src/main/java/underdogs/devbie/question/controller/QuestionController.java
+++ b/src/main/java/underdogs/devbie/question/controller/QuestionController.java
@@ -109,4 +109,12 @@ public class QuestionController {
         return ResponseEntity
             .ok(responses);
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<QuestionResponses> search(
+        @RequestParam("q") String keyword
+    ) {
+        return ResponseEntity
+            .ok(questionService.search(keyword));
+    }
 }

--- a/src/main/java/underdogs/devbie/question/controller/QuestionController.java
+++ b/src/main/java/underdogs/devbie/question/controller/QuestionController.java
@@ -54,10 +54,9 @@ public class QuestionController {
     @NoValidate
     @GetMapping
     public ResponseEntity<QuestionResponses> readAll(
-        @ModelAttribute QuestionReadRequest questionReadRequest,
         @ModelAttribute QuestionPageRequest questionPageRequest
     ) {
-        QuestionResponses responses = questionService.readAll(questionReadRequest, questionPageRequest.toPageRequest());
+        QuestionResponses responses = questionService.readAll(questionPageRequest.toPageRequest());
         return ResponseEntity
             .ok(responses);
     }
@@ -110,11 +109,12 @@ public class QuestionController {
             .ok(responses);
     }
 
+    @NoValidate
     @GetMapping("/search")
     public ResponseEntity<QuestionResponses> search(
-        @RequestParam("q") String keyword
+        @RequestParam String q
     ) {
         return ResponseEntity
-            .ok(questionService.search(keyword));
+            .ok(questionService.search(q));
     }
 }

--- a/src/main/java/underdogs/devbie/question/domain/EsQuestion.java
+++ b/src/main/java/underdogs/devbie/question/domain/EsQuestion.java
@@ -1,12 +1,17 @@
 package underdogs.devbie.question.domain;
 
+import java.util.List;
+
 import javax.persistence.Id;
 
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import underdogs.devbie.question.dto.HashtagResponse;
 
 @Document(indexName = "question")
 @NoArgsConstructor
@@ -17,15 +22,31 @@ public class EsQuestion {
     @Id
     private String id;
 
+    private String userId;
+
     private String title;
 
     private String content;
 
+    private String visits;
+
+    private String recommendedCount;
+
+    private String nonRecommendedCount;
+
+    @Field(type = FieldType.Nested)
+    private List<HashtagResponse> hashtags;
+
     public static EsQuestion from(Question question) {
         return new EsQuestion(
             String.valueOf(question.getId()),
+            String.valueOf(question.getUserId()),
             question.getTitle().getTitle(),
-            question.getContent().getContent()
+            question.getContent().getContent(),
+            String.valueOf(question.getVisits().getVisitCount()),
+            String.valueOf(question.getRecommendationCount().getRecommendedCount()),
+            String.valueOf(question.getRecommendationCount().getNonRecommendedCount()),
+            HashtagResponse.listFrom(question.getHashtags())
         );
     }
 }

--- a/src/main/java/underdogs/devbie/question/domain/EsQuestion.java
+++ b/src/main/java/underdogs/devbie/question/domain/EsQuestion.java
@@ -1,0 +1,31 @@
+package underdogs.devbie.question.domain;
+
+import javax.persistence.Id;
+
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(indexName = "question")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EsQuestion {
+
+    @Id
+    private String id;
+
+    private String title;
+
+    private String content;
+
+    public static EsQuestion from(Question question) {
+        return new EsQuestion(
+            String.valueOf(question.getId()),
+            question.getTitle().getTitle(),
+            question.getContent().getContent()
+        );
+    }
+}

--- a/src/main/java/underdogs/devbie/question/domain/repository/QuestionRepositoryCustom.java
+++ b/src/main/java/underdogs/devbie/question/domain/repository/QuestionRepositoryCustom.java
@@ -7,5 +7,5 @@ import underdogs.devbie.question.domain.Question;
 
 public interface QuestionRepositoryCustom {
 
-    Page<Question> findAllBy(String title, String content, Pageable pageable);
+    Page<Question> findAllBy(Pageable pageable);
 }

--- a/src/main/java/underdogs/devbie/question/domain/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/underdogs/devbie/question/domain/repository/QuestionRepositoryImpl.java
@@ -2,16 +2,12 @@ package underdogs.devbie.question.domain.repository;
 
 import static underdogs.devbie.question.domain.QQuestion.*;
 
-import java.util.Objects;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import underdogs.devbie.question.domain.Question;
@@ -26,42 +22,11 @@ public class QuestionRepositoryImpl extends QuerydslRepositorySupport implements
     }
 
     @Override
-    public Page<Question> findAllBy(
-        String title, String content, Pageable pageable
-    ) {
+    public Page<Question> findAllBy(Pageable pageable) {
         JPAQuery<Question> result = jpaQueryFactory
-            .selectFrom(question)
-            .where(containKeyword(title, content));
+            .selectFrom(question);
 
         QueryResults<Question> queryResults = getQuerydsl().applyPagination(pageable, result).fetchResults();
         return new PageImpl<>(queryResults.getResults(), pageable, queryResults.getTotal());
-    }
-
-    private BooleanBuilder containKeyword(String title, String content) {
-        return new BooleanBuilder()
-            .or(containTitle(title))
-            .or(containContent(content));
-    }
-
-    private BooleanExpression containTitle(String title) {
-        if (Objects.isNull(title) || title.trim().isEmpty()) {
-            return null;
-        }
-        return question
-            .title
-            .title
-            .toLowerCase()
-            .contains(title.toLowerCase());
-    }
-
-    private BooleanExpression containContent(String content) {
-        if (Objects.isNull(content) || content.trim().isEmpty()) {
-            return null;
-        }
-        return question
-            .content
-            .content
-            .toLowerCase()
-            .contains(content.toLowerCase());
     }
 }

--- a/src/main/java/underdogs/devbie/question/dto/QuestionResponse.java
+++ b/src/main/java/underdogs/devbie/question/dto/QuestionResponse.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import underdogs.devbie.question.domain.EsQuestion;
 import underdogs.devbie.question.domain.Question;
 import underdogs.devbie.user.domain.User;
 
@@ -54,6 +55,19 @@ public class QuestionResponse {
             .title(question.getTitle().getTitle())
             .content(question.getContent().getContent())
             .hashtags(HashtagResponse.listFrom(question.getHashtags()))
+            .build();
+    }
+
+    public static QuestionResponse fromEsQuestion(EsQuestion esQuestion) {
+        return QuestionResponse.builder()
+            .id(Long.parseLong(esQuestion.getId()))
+            .userId(Long.parseLong(esQuestion.getUserId()))
+            .visits(Long.parseLong(esQuestion.getVisits()))
+            .recommendedCount(Long.parseLong(esQuestion.getRecommendedCount()))
+            .nonRecommendedCount(Long.parseLong(esQuestion.getNonRecommendedCount()))
+            .title(esQuestion.getTitle())
+            .content(esQuestion.getContent())
+            .hashtags(esQuestion.getHashtags())
             .build();
     }
 }

--- a/src/main/java/underdogs/devbie/question/dto/QuestionResponses.java
+++ b/src/main/java/underdogs/devbie/question/dto/QuestionResponses.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import underdogs.devbie.question.domain.EsQuestion;
 import underdogs.devbie.question.domain.Question;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,6 +29,12 @@ public class QuestionResponses {
     public static QuestionResponses from(List<Question> questions) {
         return new QuestionResponses(questions.stream()
             .map(QuestionResponse::from)
+            .collect(Collectors.toList()), 1000);
+    }
+
+    public static QuestionResponses fromEsQuestion(List<EsQuestion> questions) {
+        return new QuestionResponses(questions.stream()
+            .map(QuestionResponse::fromEsQuestion)
             .collect(Collectors.toList()), 1000);
     }
 }

--- a/src/main/java/underdogs/devbie/question/service/EsSynchronizer.java
+++ b/src/main/java/underdogs/devbie/question/service/EsSynchronizer.java
@@ -1,0 +1,43 @@
+package underdogs.devbie.question.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import underdogs.devbie.question.domain.EsQuestion;
+import underdogs.devbie.question.domain.Question;
+import underdogs.devbie.question.domain.repository.QuestionRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EsSynchronizer implements ApplicationRunner {
+
+    private final QuestionRepository questionRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Transactional
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Start syncing - {}", LocalDateTime.now());
+        this.syncQuestions();
+        log.info("End syncing - {}", LocalDateTime.now());
+    }
+
+    private void syncQuestions() {
+        if (!elasticsearchOperations.indexOps(EsQuestion.class).exists()) {
+            List<Question> questionList = questionRepository.findAll();
+            for (Question question : questionList) {
+                log.info("Syncing Question - {}", question.getId());
+                elasticsearchOperations.save(EsQuestion.from(question));
+            }
+        }
+    }
+}

--- a/src/main/java/underdogs/devbie/question/service/InitialEsSynchronizer.java
+++ b/src/main/java/underdogs/devbie/question/service/InitialEsSynchronizer.java
@@ -18,7 +18,7 @@ import underdogs.devbie.question.domain.repository.QuestionRepository;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class EsSynchronizer implements ApplicationRunner {
+public class InitialEsSynchronizer implements ApplicationRunner {
 
     private final QuestionRepository questionRepository;
     private final ElasticsearchOperations elasticsearchOperations;

--- a/src/main/java/underdogs/devbie/question/service/QuestionDeleteEvent.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionDeleteEvent.java
@@ -1,0 +1,18 @@
+package underdogs.devbie.question.service;
+
+import org.springframework.context.ApplicationEvent;
+
+import lombok.Getter;
+import underdogs.devbie.question.domain.Question;
+
+@Getter
+public class QuestionDeleteEvent extends ApplicationEvent {
+
+    private final Question question;
+
+    public QuestionDeleteEvent(Object source, Question question) {
+        super(source);
+        this.question = question;
+    }
+}
+

--- a/src/main/java/underdogs/devbie/question/service/QuestionListener.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionListener.java
@@ -1,0 +1,29 @@
+package underdogs.devbie.question.service;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import underdogs.devbie.question.domain.EsQuestion;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionListener {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Async("threadPoolTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void syncUpsertElasticSearch(QuestionUpsertEvent event) {
+        elasticsearchOperations.save(EsQuestion.from(event.getQuestion()));
+    }
+
+    @Async("threadPoolTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void syncDeleteElasticSearch(QuestionDeleteEvent event) {
+        elasticsearchOperations.delete(EsQuestion.from(event.getQuestion()));
+    }
+}

--- a/src/main/java/underdogs/devbie/question/service/QuestionService.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionService.java
@@ -83,6 +83,8 @@ public class QuestionService {
 
         question.updateQuestionInfo(request.toEntity(userId));
         questionHashtagService.updateHashtags(question, request.getHashtags());
+
+        elasticsearchOperations.save(EsQuestion.from(question));
     }
 
     private void validateQuestionAuthor(Long userId, Question question) {
@@ -102,6 +104,8 @@ public class QuestionService {
         validateQuestionAuthorOrAdmin(user, question);
 
         questionRepository.deleteById(questionId);
+
+        elasticsearchOperations.delete(EsQuestion.from(question));
     }
 
     private void validateQuestionAuthorOrAdmin(User user, Question question) {

--- a/src/main/java/underdogs/devbie/question/service/QuestionService.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionService.java
@@ -54,11 +54,8 @@ public class QuestionService {
         return savedQuestion.getId();
     }
 
-    public QuestionResponses readAll(QuestionReadRequest questionReadRequest, Pageable pageable) {
-        Page<Question> questions = questionRepository.findAllBy(
-            questionReadRequest.getTitle(),
-            questionReadRequest.getContent(),
-            pageable);
+    public QuestionResponses readAll(Pageable pageable) {
+        Page<Question> questions = questionRepository.findAllBy(pageable);
         return QuestionResponses.of(questions.getContent(), questions.getTotalPages());
     }
 

--- a/src/main/java/underdogs/devbie/question/service/QuestionUpsertEvent.java
+++ b/src/main/java/underdogs/devbie/question/service/QuestionUpsertEvent.java
@@ -1,0 +1,17 @@
+package underdogs.devbie.question.service;
+
+import org.springframework.context.ApplicationEvent;
+
+import lombok.Getter;
+import underdogs.devbie.question.domain.Question;
+
+@Getter
+public class QuestionUpsertEvent extends ApplicationEvent {
+
+    private final Question question;
+
+    public QuestionUpsertEvent(Object source, Question question) {
+        super(source);
+        this.question = question;
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -86,6 +86,19 @@ INSERT INTO question (recommended_count, non_recommended_count, created_date, id
 INSERT INTO question (recommended_count, non_recommended_count, created_date, id, user_id, title, content, visit_count) VALUES (17, 5, '2020-08-28 02:35:42', 38, 100, 'h2방언','PUT과 PATCH가 둘다 수정을 위한 HTTP METHOD로 알고 있는데, 어떤 차이가 있나요?', 500);
 INSERT INTO question (recommended_count, non_recommended_count, created_date, id, user_id, title, content, visit_count) VALUES (10, 5, '2020-08-28 02:35:43', 39, 54, '도커가 무엇인가요?','PUT과 PATCH가 둘다 수정을 위한 HTTP METHOD로 알고 있는데, 어떤 차이가 있나요?', 211);
 
+INSERT INTO hashtag (name) VALUES ('java');
+INSERT INTO hashtag (name) VALUES ('network');
+INSERT INTO hashtag (name) VALUES ('database');
+INSERT INTO hashtag (name) VALUES ('elastic');
+INSERT INTO hashtag (name) VALUES ('event');
+INSERT INTO hashtag (name) VALUES ('programming');
+
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (1, 1);
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (1, 2);
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (2, 3);
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (2, 4);
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (1, 5);
+INSERT INTO question_hashtag (question_id, hashtag_id) VALUES (3, 6);
 
 INSERT INTO answer (recommended_count, non_recommended_count, id, user_id, question_id, content) VALUES (11, 4, 1, 100, 1,'가비지 컬렉션 중요합니다. 기본적인 작동 원리는 알아야 합니다. 자세한 내용은 구글링 해보세요');
 INSERT INTO answer (recommended_count, non_recommended_count, id, user_id, question_id, content) VALUES (12, 4, 2, 54, 1,'가비지 컬렉션 중요합니다. 기본적인 작동 원리는 알아야 합니다. 자세한 내용은 구글링 해보세요');

--- a/src/test/java/underdogs/devbie/question/acceptance/QuestionAcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/question/acceptance/QuestionAcceptanceTest.java
@@ -70,17 +70,6 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
                     () -> assertThat(firstQuestion.getContent()).isEqualTo(TEST_QUESTION_CONTENT)
                 );
             }),
-            dynamicTest("특정 질문 검색", () -> {
-                QuestionResponses searchedQuestions = get("/api/questions?title=" + SEARCH_KEYWORD + "&content=" + SEARCH_KEYWORD
-                    + "&page=1&orderBy=CREATED_DATE",
-                    QuestionResponses.class);
-
-                assertAll(
-                    () -> assertThat(searchedQuestions.getQuestions()).hasSize(1),
-                    () -> assertThat(searchedQuestions.getQuestions().get(0).getTitle()).isEqualTo(
-                        TEST_TITLE_FOR_SEARCH)
-                );
-            }),
             dynamicTest("엘라스틱 서치 키워드로 질문 검색", () -> {
                 QuestionResponses searchedQuestions = get("/api/questions/search?q=" + SEARCH_KEYWORD, QuestionResponses.class);
 

--- a/src/test/java/underdogs/devbie/question/acceptance/QuestionAcceptanceTest.java
+++ b/src/test/java/underdogs/devbie/question/acceptance/QuestionAcceptanceTest.java
@@ -81,6 +81,15 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
                         TEST_TITLE_FOR_SEARCH)
                 );
             }),
+            dynamicTest("엘라스틱 서치 키워드로 질문 검색", () -> {
+                QuestionResponses searchedQuestions = get("/api/questions/search?q=" + SEARCH_KEYWORD, QuestionResponses.class);
+
+                assertAll(
+                    () -> assertThat(searchedQuestions.getQuestions()).hasSize(1),
+                    () -> assertThat(searchedQuestions.getQuestions().get(0).getTitle()).isEqualTo(
+                        TEST_TITLE_FOR_SEARCH)
+                );
+            }),
             dynamicTest("질문 조회", () -> {
                 QuestionResponse firstQuestion = fetchFirstQuestion();
 

--- a/src/test/java/underdogs/devbie/question/controller/QuestionControllerTest.java
+++ b/src/test/java/underdogs/devbie/question/controller/QuestionControllerTest.java
@@ -31,7 +31,6 @@ import underdogs.devbie.question.domain.QuestionHashtags;
 import underdogs.devbie.question.domain.QuestionTitle;
 import underdogs.devbie.question.dto.HashtagResponse;
 import underdogs.devbie.question.dto.QuestionCreateRequest;
-import underdogs.devbie.question.dto.QuestionReadRequest;
 import underdogs.devbie.question.dto.QuestionResponse;
 import underdogs.devbie.question.dto.QuestionResponses;
 import underdogs.devbie.question.dto.QuestionUpdateRequest;
@@ -93,7 +92,7 @@ class QuestionControllerTest extends MvcTest {
             .build();
         QuestionResponses responses = QuestionResponses.from(Lists.newArrayList(question));
 
-        given(questionService.readAll(any(QuestionReadRequest.class), any())).willReturn(responses);
+        given(questionService.readAll(any())).willReturn(responses);
 
         MvcResult mvcResult = getAction("/api/questions?title=&content=&page=1&orderBy=CREATED_DATE")
             .andExpect(status().isOk())
@@ -183,7 +182,7 @@ class QuestionControllerTest extends MvcTest {
 
         QuestionResponses responses = QuestionResponses.from(Lists.newArrayList(question1, question2));
 
-        given(questionService.readAll(any(QuestionReadRequest.class), any())).willReturn(responses);
+        given(questionService.readAll(any())).willReturn(responses);
 
         MvcResult mvcResult = getAction("/api/questions?page=1&orderBy=CREATED_DATE&title=스택&content=")
             .andExpect(status().isOk())

--- a/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
+++ b/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import underdogs.devbie.question.domain.Hashtag;
 import underdogs.devbie.question.domain.OrderBy;
@@ -29,9 +30,9 @@ import underdogs.devbie.question.domain.Question;
 import underdogs.devbie.question.domain.QuestionContent;
 import underdogs.devbie.question.domain.QuestionHashtag;
 import underdogs.devbie.question.domain.QuestionHashtags;
-import underdogs.devbie.question.domain.repository.QuestionRepository;
 import underdogs.devbie.question.domain.QuestionTitle;
 import underdogs.devbie.question.domain.TagName;
+import underdogs.devbie.question.domain.repository.QuestionRepository;
 import underdogs.devbie.question.dto.HashtagResponse;
 import underdogs.devbie.question.dto.QuestionCreateRequest;
 import underdogs.devbie.question.dto.QuestionPageRequest;
@@ -61,6 +62,9 @@ public class QuestionServiceTest {
     @Mock
     private QuestionRepository questionRepository;
 
+    @Mock
+    private ElasticsearchOperations elasticsearchOperations;
+
     private User user;
 
     private Question question;
@@ -69,7 +73,7 @@ public class QuestionServiceTest {
 
     @BeforeEach
     void setUp() {
-        questionService = new QuestionService(userService, questionHashtagService, questionRepository);
+        questionService = new QuestionService(userService, questionHashtagService, questionRepository, elasticsearchOperations);
 
         user = User.builder()
             .id(1L)

--- a/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
+++ b/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -63,6 +64,9 @@ public class QuestionServiceTest {
     private QuestionRepository questionRepository;
 
     @Mock
+    private ApplicationEventPublisher publisher;
+
+    @Mock
     private ElasticsearchOperations elasticsearchOperations;
 
     private User user;
@@ -73,7 +77,7 @@ public class QuestionServiceTest {
 
     @BeforeEach
     void setUp() {
-        questionService = new QuestionService(userService, questionHashtagService, questionRepository, elasticsearchOperations);
+        questionService = new QuestionService(userService, questionHashtagService, questionRepository, publisher, elasticsearchOperations);
 
         user = User.builder()
             .id(1L)

--- a/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
+++ b/src/test/java/underdogs/devbie/question/service/QuestionServiceTest.java
@@ -37,7 +37,6 @@ import underdogs.devbie.question.domain.repository.QuestionRepository;
 import underdogs.devbie.question.dto.HashtagResponse;
 import underdogs.devbie.question.dto.QuestionCreateRequest;
 import underdogs.devbie.question.dto.QuestionPageRequest;
-import underdogs.devbie.question.dto.QuestionReadRequest;
 import underdogs.devbie.question.dto.QuestionResponse;
 import underdogs.devbie.question.dto.QuestionResponses;
 import underdogs.devbie.question.dto.QuestionUpdateRequest;
@@ -127,11 +126,10 @@ public class QuestionServiceTest {
     @Test
     void readAll() {
         Page<Question> questions = new PageImpl<>(Lists.newArrayList(question));
-        given(questionRepository.findAllBy(anyString(), anyString(), any(Pageable.class))).willReturn(questions);
+        given(questionRepository.findAllBy(any(Pageable.class))).willReturn(questions);
 
-        QuestionReadRequest questionReadRequest = QuestionReadRequest.builder().title("").content("").build();
         QuestionPageRequest questionPageRequest = new QuestionPageRequest(1, OrderBy.CREATED_DATE);
-        QuestionResponses responses = questionService.readAll(questionReadRequest, questionPageRequest.toPageRequest());
+        QuestionResponses responses = questionService.readAll(questionPageRequest.toPageRequest());
 
         QuestionResponse response = responses.getQuestions().get(0);
         assertAll(
@@ -248,11 +246,10 @@ public class QuestionServiceTest {
             .build();
 
         Page<Question> questions = new PageImpl<>(Lists.newArrayList(question1, question2));
-        given(questionRepository.findAllBy(anyString(), anyString(), any(Pageable.class))).willReturn(questions);
+        given(questionRepository.findAllBy(any(Pageable.class))).willReturn(questions);
 
-        QuestionReadRequest questionReadRequest = QuestionReadRequest.builder().title("스택").content("").build();
         QuestionPageRequest questionPageRequest = new QuestionPageRequest(1, OrderBy.CREATED_DATE);
-        QuestionResponses responses = questionService.readAll(questionReadRequest, questionPageRequest.toPageRequest());
+        QuestionResponses responses = questionService.readAll(questionPageRequest.toPageRequest());
 
         assertAll(
             () -> assertThat(responses.getQuestions().get(0).getTitle()).isEqualTo("스택과 큐의 차이"),


### PR DESCRIPTION
## Resolve #318 

- 현재 질문검색은 mysql에서 %like% 조건문으로 검색이 이루어지는데 Like구문은 인덱스 적용이 안되어서 데이터가 많아지면 응답 속도가 느려진다.
- 엘라스틱 서치는 역색인을 제공하기 때문에 검색 속도가 빠르다. 

## Changes

- spring-data-elasticsearch를 이용해서 client bean 추가
- 이벤트리스너를 통해 Mysql와 엘라스틱서치 데이터베이스 동기화

## Notes
- 서버 도커에 엘라스틱서치를 설치해야 된다. (클라이언트 커넥션 때문에 CI가 안돌아가는데, 곧 보수하고 이어서 서버 도커에도 작업할 예정)
- 기존에 있던 데이터를 동기화하기 위해 application runner를 상속받은 빈을 만들었다.

## References

- [spring-data-elasticsearch](https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/)
