### PR TITLE
refactor: 즐겨찾기 서비스에서 UserService 의존성 제거

### DIFF
--- a/src/main/java/underdogs/devbie/favorite/service/FavoriteService.java
+++ b/src/main/java/underdogs/devbie/favorite/service/FavoriteService.java
@@ -8,14 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import underdogs.devbie.exception.NotExistException;
 import underdogs.devbie.favorite.domain.Favorite;
 import underdogs.devbie.favorite.domain.FavoriteRepository;
-import underdogs.devbie.user.service.UserService;
 
 @Service
 @Transactional(readOnly = true)
 public abstract class FavoriteService<T extends Favorite> {
 
     protected FavoriteRepository favoriteRepository;
-    protected UserService userService;
 
     public abstract Object findFavorites(Long userId);
 

--- a/src/main/java/underdogs/devbie/favorite/service/NoticeFavoriteService.java
+++ b/src/main/java/underdogs/devbie/favorite/service/NoticeFavoriteService.java
@@ -11,17 +11,15 @@ import underdogs.devbie.favorite.domain.NoticeFavorite;
 import underdogs.devbie.favorite.domain.NoticeFavoriteRepository;
 import underdogs.devbie.notice.dto.NoticeResponses;
 import underdogs.devbie.notice.service.NoticeService;
-import underdogs.devbie.user.service.UserService;
 
 @Service
 public class NoticeFavoriteService extends FavoriteService {
 
     private NoticeService noticeService;
 
-    public NoticeFavoriteService(NoticeFavoriteRepository noticeFavoriteRepository, UserService userService,
+    public NoticeFavoriteService(NoticeFavoriteRepository noticeFavoriteRepository,
         NoticeService noticeService) {
         this.favoriteRepository = noticeFavoriteRepository;
-        this.userService = userService;
         this.noticeService = noticeService;
     }
 

--- a/src/main/java/underdogs/devbie/favorite/service/QuestionFavoriteService.java
+++ b/src/main/java/underdogs/devbie/favorite/service/QuestionFavoriteService.java
@@ -11,17 +11,15 @@ import underdogs.devbie.favorite.domain.QuestionFavorite;
 import underdogs.devbie.favorite.domain.QuestionFavoriteRepository;
 import underdogs.devbie.question.dto.QuestionResponses;
 import underdogs.devbie.question.service.QuestionService;
-import underdogs.devbie.user.service.UserService;
 
 @Service
 public class QuestionFavoriteService extends FavoriteService {
 
     private QuestionService questionService;
 
-    public QuestionFavoriteService(QuestionFavoriteRepository questionFavoriteRepository, UserService userService,
+    public QuestionFavoriteService(QuestionFavoriteRepository questionFavoriteRepository,
         QuestionService questionService) {
         this.favoriteRepository = questionFavoriteRepository;
-        this.userService = userService;
         this.questionService = questionService;
     }
 

--- a/src/test/java/underdogs/devbie/favorite/service/NoticeFavoriteServiceTest.java
+++ b/src/test/java/underdogs/devbie/favorite/service/NoticeFavoriteServiceTest.java
@@ -18,7 +18,6 @@ import underdogs.devbie.exception.BadRequestException;
 import underdogs.devbie.favorite.domain.NoticeFavorite;
 import underdogs.devbie.favorite.domain.NoticeFavoriteRepository;
 import underdogs.devbie.notice.service.NoticeService;
-import underdogs.devbie.user.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 class NoticeFavoriteServiceTest {
@@ -27,16 +26,13 @@ class NoticeFavoriteServiceTest {
 
     @Mock
     NoticeFavoriteRepository noticeFavoriteRepository;
-
-    @Mock
-    UserService userService;
-
+    
     @Mock
     NoticeService noticeService;
 
     @BeforeEach
     void setUp() {
-        noticeFavoriteService = new NoticeFavoriteService(noticeFavoriteRepository, userService, noticeService);
+        noticeFavoriteService = new NoticeFavoriteService(noticeFavoriteRepository, noticeService);
     }
 
     @DisplayName("공고 즐겨찾기 조회")

--- a/src/test/java/underdogs/devbie/favorite/service/QuestionFavoriteServiceTest.java
+++ b/src/test/java/underdogs/devbie/favorite/service/QuestionFavoriteServiceTest.java
@@ -18,7 +18,6 @@ import underdogs.devbie.exception.BadRequestException;
 import underdogs.devbie.favorite.domain.QuestionFavorite;
 import underdogs.devbie.favorite.domain.QuestionFavoriteRepository;
 import underdogs.devbie.question.service.QuestionService;
-import underdogs.devbie.user.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 class QuestionFavoriteServiceTest {
@@ -29,14 +28,11 @@ class QuestionFavoriteServiceTest {
     QuestionFavoriteRepository questionFavoriteRepository;
 
     @Mock
-    UserService userService;
-
-    @Mock
     QuestionService questionService;
 
     @BeforeEach
     void setUp() {
-        questionFavoriteService = new QuestionFavoriteService(questionFavoriteRepository, userService, questionService);
+        questionFavoriteService = new QuestionFavoriteService(questionFavoriteRepository, questionService);
     }
 
     @DisplayName("질문 즐겨찾기 조회")


### PR DESCRIPTION
## Resolve #324 

- 즐겨찾기 서비스에서 UserService 를 사용하지 않는다.

## Changes

- 즐겨찾기 서비스에서 UserService 의존성 제거

## Notes

- N/A

## References

- N/A
