### PR TITLE
feat: test coverage 전체 90%로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,12 +133,10 @@ jacocoTestCoverageVerification {
 
     violationRules {
         rule {
-            element = 'CLASS'
-
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.80
+                minimum = 0.90
             }
 
             includes = ['*.domain.*']


### PR DESCRIPTION
## Resolve #326 

- 테스트 커버리지를 90으로 올린다.

## Changes

- jacoco criteria 전체, Instruction, 90으로 조정.

## Notes

- N/A

## References

- N/A
