### PR TITLE
feat: 정적 코드 분석 툴 SonarQube 적용

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,14 @@ cache:
 script: "./gradlew clean build"
 
 after_success:
+  - ./gradlew sonarqube -Dsonar.projectKey=devbie-sonarqube -Dsonar.host.url=http://3.34.66.245:8000 -Dsonar.login=$SONAR_TOKEN
   - if [ $TRAVIS_PULL_REQUEST == "false" ]; then
-    cd docker;
-    git add .;
-    git commit -m "updated in travis";
-    git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker;
-    cd ..;
-    docker build -t kimseonggyu1/devbie:latest .;
-    docker login -u $DOCKER_USER -p $PASSWORD;
-    docker push kimseonggyu1/devbie:latest;
-    fi
+  cd docker;
+  git add .;
+  git commit -m "updated in travis";
+  git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker;
+  cd ..;
+  docker build -t kimseonggyu1/devbie:latest .;
+  docker login -u $DOCKER_USER -p $PASSWORD;
+  docker push kimseonggyu1/devbie:latest;
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ script: "./gradlew clean build"
 after_success:
   - ./gradlew sonarqube -Dsonar.projectKey=devbie-sonarqube -Dsonar.host.url=http://3.34.66.245:8000 -Dsonar.login=$SONAR_TOKEN
   - if [ $TRAVIS_PULL_REQUEST == "false" ]; then
-  cd docker;
-  git add .;
-  git commit -m "updated in travis";
-  git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker;
-  cd ..;
-  docker build -t kimseonggyu1/devbie:latest .;
-  docker login -u $DOCKER_USER -p $PASSWORD;
-  docker push kimseonggyu1/devbie:latest;
-  fi
+    cd docker;
+    git add .;
+    git commit -m "updated in travis";
+    git push https://$GITHUB_INFO@github.com/KimSeongGyu1/devbie_docker;
+    cd ..;
+    docker build -t kimseonggyu1/devbie:latest .;
+    docker login -u $DOCKER_USER -p $PASSWORD;
+    docker push kimseonggyu1/devbie:latest;
+    fi

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,15 @@ plugins {
 
 sonarqube {
     properties {
-        property "sonar.exclusions", "**/src/test/**/*.java, **/src/frontend/**/*"
+        property "sonar.host.url", "http://3.34.66.245:8000"
+        property "sonar.login", "34546e1ca530e25c6d1481fd76fc4ad32d7cfdf0"        // 로그인 id 또는 인증토큰
+        property "sonar.sources", "src"
+        property "sonar.language", "java"
+        property "sonar.projectVersion", "1.0"
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.profile", "Sonar way"
+        property "sonar.test.inclusions", "**/*Test.java"
+        property "sonar.exclusions", "**/src/frontend/**/*"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,13 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'application'
+    id "org.sonarqube" version "2.7"
+}
+
+sonarqube {
+    properties {
+        property "sonar.exclusions", "**/src/test/**/*.java, **/src/frontend/**/*"
+    }
 }
 
 group = 'underdogs'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
+    def props = new Properties()
+    file('src/main/resources/properties/local/application.properties').withInputStream {
+        props.load(it)
+    }
     ext {
         querydslPluginVersion = '1.0.10'
+        sonarToken = props['sonar.token']
     }
     repositories {
         maven { url "https://plugins.gradle.org/m2/" } // plugin 저장소
@@ -23,7 +28,7 @@ plugins {
 sonarqube {
     properties {
         property "sonar.host.url", "http://3.34.66.245:8000"
-        property "sonar.login", "34546e1ca530e25c6d1481fd76fc4ad32d7cfdf0"        // 로그인 id 또는 인증토큰
+        property "sonar.login", "${sonarToken}"
         property "sonar.sources", "src"
         property "sonar.language", "java"
         property "sonar.projectVersion", "1.0"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=develop
+spring.profiles.active=local

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=local
+spring.profiles.active=develop


### PR DESCRIPTION
## Resolve #333 

- 정적 코드 분석 툴인 SonarQube를 적용해 코드 품질을 높인다.

## Changes

- webhook EC2 서버에 소나큐브 설치 후 실행
- Travis 빌드 시 소나큐브 서버에서 정적 코드 분석

## Notes

- Travis 빌드 시 정적 분석 툴이 동작합니다.
- 정적 분석 툴 결과는 [링크](http://3.34.66.245:8000/projects)에서 확인 할 수 있습니다.
- 로컬에서 SonarQube를 실행하고 싶으면 오른쪽 gradle 탭에서 sonarqube를 더블 클릭하며 됩니다. (queryDSL 빌드하는 것과 동일)

## References

- [도란도란 팀 노션](https://www.notion.so/sonarqube-dddacb2c16d945e8a4ff2fd1978f781a)
- [Travis CI와 GitHub 기반의 Vue.js+SpringBoot 개발환경 구축하기](https://medium.com/@alvin.h/travis-ci%EC%99%80-github-%EA%B8%B0%EB%B0%98%EC%9D%98-vue-js-springboot-%EA%B0%9C%EB%B0%9C%ED%99%98%EA%B2%BD-%EA%B5%AC%EC%B6%95%ED%95%98%EA%B8%B0-93e40af572ab)
